### PR TITLE
chore(orchestration-service): add Dockerfile for Render

### DIFF
--- a/orchestration-service/.dockerignore
+++ b/orchestration-service/.dockerignore
@@ -1,0 +1,6 @@
+target/
+.git
+.gitignore
+Dockerfile
+.dockerignore
+README.md

--- a/orchestration-service/Dockerfile
+++ b/orchestration-service/Dockerfile
@@ -1,0 +1,16 @@
+# ===== Stage 1: Build (usa wrapper do monorepo) =====
+FROM eclipse-temurin:21-jdk AS build
+WORKDIR /repo
+COPY . .
+# torna o wrapper executável, se existir
+RUN chmod +x ./mvnw || true
+# Tenta buildar pelo parent agregador; se não houver, usa o pom do módulo
+RUN ./mvnw -B -DskipTests -pl orchestration-service -am clean package \
+ || ./mvnw -B -DskipTests -f orchestration-service/pom.xml clean package
+
+# ===== Stage 2: Runtime enxuto =====
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /repo/orchestration-service/target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["sh","-c","java -Dserver.port=$PORT -Dspring.profiles.active=$SPRING_PROFILES_ACTIVE -jar app.jar"]


### PR DESCRIPTION
## O que foi feito
- Adicionado `orchestration-service/Dockerfile` (multi-stage: build com JDK 21 e runtime com JRE 21).
- Adicionado `orchestration-service/.dockerignore`.
- Sem mudanças funcionais no código do serviço.

## Por quê
Preparar o `orchestration-service` para deploy no Render usando Docker em monorepo, sem depender de runtime do Render.

## Como funciona
- Build: usa `mvnw` da raiz e compila apenas o módulo `orchestration-service` (`-pl orchestration-service -am`). 
- Runtime: copia o `*.jar` gerado para uma imagem JRE enxuta e inicia com:
  `java -Dserver.port=$PORT -Dspring.profiles.active=$SPRING_PROFILES_ACTIVE -jar app.jar`

## Instruções de deploy no Render (DEV)
- **Branch:** `develop`
- **Dockerfile Path:** `orchestration-service/Dockerfile`
- **Root Directory:** (deixe em branco)
- **Health Check Path:** `/actuator/health` (requer actuator no pom; temporariamente usar `/` se necessário)
- **Env vars (serviço ou Env Group -dev):**
  - `SPRING_PROFILES_ACTIVE=dev`
  - `DB_URL=jdbc:postgresql://<host>:5432/<db>?sslmode=require`
  - `DB_USERNAME=<usuario>`
  - `DB_PASSWORD=<senha>`
  - `ALLOWED_ORIGINS=https://develop--<site>.netlify.app`
  - (opcional) `JAVA_TOOL_OPTIONS=-XX:MaxRAMPercentage=75.0`
  - (opcional) `TZ=America/Sao_Paulo`

## Como testar local
```bash
# na raiz do repo
docker build -f orchestration-service/Dockerfile -t orchestration-service:dev .
docker run --rm -p 8080:8080 \
  -e PORT=8080 \
  -e SPRING_PROFILES_ACTIVE=dev \
  -e DB_URL="jdbc:postgresql://<host>:5432/<db>?sslmode=require" \
  -e DB_USERNAME=<usuario> \
  -e DB_PASSWORD=<senha> \
  orchestration-service:dev
# depois abra http://localhost:8080/actuator/health