### PR TITLE
fix: Dockerfile para Deploy no Render (Orchestration Service)

### DIFF
--- a/orchestration-service/.dockerignore
+++ b/orchestration-service/.dockerignore
@@ -1,6 +1,7 @@
-target/
+target
 .git
 .gitignore
-Dockerfile
-.dockerignore
-README.md
+**/.idea
+**/.vscode
+**/node_modules
+**/.DS_Store

--- a/orchestration-service/Dockerfile
+++ b/orchestration-service/Dockerfile
@@ -1,16 +1,37 @@
-# ===== Stage 1: Build (usa wrapper do monorepo) =====
+# ===== Stage 1: Build =====
 FROM eclipse-temurin:21-jdk AS build
 WORKDIR /repo
-COPY . .
-# torna o wrapper executável, se existir
-RUN chmod +x ./mvnw || true
-# Tenta buildar pelo parent agregador; se não houver, usa o pom do módulo
-RUN ./mvnw -B -DskipTests -pl orchestration-service -am clean package \
- || ./mvnw -B -DskipTests -f orchestration-service/pom.xml clean package
 
-# ===== Stage 2: Runtime enxuto =====
+# Copia apenas o necessário primeiro (melhor cache)
+COPY .mvn/ .mvn/
+COPY mvnw pom.xml ./
+COPY orchestration-service/pom.xml orchestration-service/pom.xml
+# (se houver dependências compartilhadas)
+COPY shared-libs/pom.xml shared-libs/pom.xml || true
+
+# Depois os fontes
+COPY orchestration-service/ orchestration-service/
+COPY shared-libs/ shared-libs/ || true
+
+RUN chmod +x mvnw
+# -pl orchestration-service -am garante build das dependências do módulo
+RUN ./mvnw -B -DskipTests --no-transfer-progress \
+    -pl orchestration-service -am clean package
+
+# ===== Stage 2: Runtime =====
 FROM eclipse-temurin:21-jre
 WORKDIR /app
-COPY --from=build /repo/orchestration-service/target/*.jar app.jar
+
+# copia o jar gerado (wildcard ok)
+ARG JAR_PATH=/repo/orchestration-service/target/*-SNAPSHOT.jar
+COPY --from=build ${JAR_PATH} app.jar
+
+# Ajuste de memória em container pequeno (Render Free/Starter)
+ENV JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0"
+
+# Render injeta $PORT; deixamos o padrão local em 8080
+ENV SPRING_PROFILES_ACTIVE=prod
 EXPOSE 8080
-ENTRYPOINT ["sh","-c","java -Dserver.port=$PORT -Dspring.profiles.active=$SPRING_PROFILES_ACTIVE -jar app.jar"]
+
+# Usa $PORT do Render quando existir
+CMD ["sh","-c","java -Dserver.port=${PORT:-8080} -Dspring.profiles.active=${SPRING_PROFILES_ACTIVE} -jar app.jar"]


### PR DESCRIPTION
Durante o processo de deploy do orchestration-service no Render, o container não subia corretamente devido a inconsistências no Dockerfile.

**Os principais problemas identificados foram:**

1. O Dockerfile não considerava corretamente a estrutura de monorepo.
2. A configuração de porta não estava compatível com a variável de ambiente $PORT que o Render injeta.
3. Ausência de otimizações para limitar o consumo de memória em ambientes free/low tier do Render.

**Alterações Realizadas**

- Reestruturado o Dockerfile do orchestration-service:
   - Adicionado Stage de build usando eclipse-temurin:21-jdk.
   - Inclusão de COPY seletivo para garantir cache de dependências Maven.
   - Build configurado com -pl orchestration-service -am para compilar apenas o módulo e suas dependências (shared-libs).
   - Novo Stage runtime usando eclipse-temurin:21-jre (imagem enxuta).
   - Parametrização do server.port com fallback (${PORT:-8080}).
   - Adição de JAVA_TOOL_OPTIONS="-XX:MaxRAMPercentage=75.0" para evitar OOM no Render.
- Criado .dockerignore no módulo:
   - Ignorando target, .git, IDE configs e node_modules.

**Resultados Esperados**

- Deploy funcional do orchestration-service no Render, tanto em ambiente prod quanto local.
- Build mais eficiente e com cache reaproveitado.
- Melhor compatibilidade com ambientes de memória reduzida.
- Configuração clara e isolada no contexto do monorepo.

Como Testar

1. Buildar localmente o container:
```bash
docker build -t orchestration-service -f orchestration-service/Dockerfile .
docker run -p 8080:8080 orchestration-service
``` 
O serviço deve iniciar e estar acessível em http://localhost:8080.

2. Verificar no Render:

- Configurar Web Service para usar o orchestration-service/Dockerfile.
- Definir variáveis de ambiente (SPRING_PROFILES_ACTIVE=prod, DB_*).
- Confirmar que o deploy sobe sem erros.

**Observação: esse PR é fix, não traz features novas. Focado em corrigir o processo de build/deploy.**