### PR TITLE
feat(orchestration): integração com user-service via OpenFeign

### DIFF
--- a/orchestration-service/pom.xml
+++ b/orchestration-service/pom.xml
@@ -70,6 +70,10 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/OrchestrationServiceApplication.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/OrchestrationServiceApplication.java
@@ -4,12 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
-@EnableFeignClients
+@EnableFeignClients(basePackages = "com.squadprisma.notesoccer.orchestration_service")
 @SpringBootApplication
 public class OrchestrationServiceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(OrchestrationServiceApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(OrchestrationServiceApplication.class, args);
+    }
 
 }

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationUsuarioController.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationUsuarioController.java
@@ -1,0 +1,29 @@
+package com.squadprisma.notesoccer.orchestration_service.api.controller;
+
+import com.squadprisma.notesoccer.orchestration_service.api.dto.CreateUsuarioRequest;
+import com.squadprisma.notesoccer.orchestration_service.api.dto.UsuarioResponse;
+import com.squadprisma.notesoccer.orchestration_service.application.service.UserOrchestrationService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/orchestration/v1/usuarios")
+public class OrchestrationUsuarioController {
+
+    private final UserOrchestrationService service;
+
+    public OrchestrationUsuarioController(UserOrchestrationService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    public ResponseEntity<UsuarioResponse> criar(@Valid @RequestBody CreateUsuarioRequest req) {
+        var created = service.criarUsuario(req);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
+    }
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/CreateUsuarioRequest.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/CreateUsuarioRequest.java
@@ -1,0 +1,5 @@
+package com.squadprisma.notesoccer.orchestration_service.api.dto;
+
+//request
+public record CreateUsuarioRequest(
+        String nome, String email, String senha, String apelido, String whatsapp) {}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/UsuarioResponse.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/UsuarioResponse.java
@@ -1,0 +1,7 @@
+package com.squadprisma.notesoccer.orchestration_service.api.dto;
+
+import java.util.UUID;
+
+//response
+public record UsuarioResponse(
+        UUID id, String nome, String email, String apelido, String whatsapp) {}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/application/port/out/UserServicePort.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/application/port/out/UserServicePort.java
@@ -1,0 +1,8 @@
+package com.squadprisma.notesoccer.orchestration_service.application.port.out;
+
+import com.squadprisma.notesoccer.orchestration_service.api.dto.CreateUsuarioRequest;
+import com.squadprisma.notesoccer.orchestration_service.api.dto.UsuarioResponse;
+
+public interface UserServicePort {
+    UsuarioResponse criarUsuario(CreateUsuarioRequest request);
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/application/service/UserOrchestrationService.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/application/service/UserOrchestrationService.java
@@ -1,0 +1,35 @@
+package com.squadprisma.notesoccer.orchestration_service.application.service;
+
+import com.squadprisma.notesoccer.orchestration_service.api.dto.CreateUsuarioRequest;
+import com.squadprisma.notesoccer.orchestration_service.api.dto.UsuarioResponse;
+import com.squadprisma.notesoccer.orchestration_service.application.port.out.UserServicePort;
+import feign.FeignException;
+import feign.RetryableException;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class UserOrchestrationService {
+
+    private final UserServicePort userPort;
+
+    public UserOrchestrationService(UserServicePort userPort) {
+        this.userPort = userPort;
+    }
+
+    public UsuarioResponse criarUsuario(CreateUsuarioRequest req) {
+        try {
+            return userPort.criarUsuario(req);
+        } catch (FeignException.Conflict e) {
+            // 409 do user-service (e-mail duplicado, por ex.)
+            throw new ResponseStatusException(HttpStatus.CONFLICT, e.contentUTF8(), e);
+        } catch (RetryableException e){
+            throw new ResponseStatusException(HttpStatus.GATEWAY_TIMEOUT, "user-service timeout", e);
+        } catch (FeignException e) {
+            // qualquer outro erro do user-service
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY,
+                    "user-service error: " + e.status(), e);
+        }
+    }
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/clients/UserServiceClient.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/clients/UserServiceClient.java
@@ -1,11 +1,19 @@
 package com.squadprisma.notesoccer.orchestration_service.infra.clients;
 
+import com.squadprisma.notesoccer.orchestration_service.api.dto.CreateUsuarioRequest;
+import com.squadprisma.notesoccer.orchestration_service.api.dto.UsuarioResponse;
+import com.squadprisma.notesoccer.orchestration_service.integrations.UserServiceFeignConfig;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
-@FeignClient(name = "user-service", url = "${clients.user-service.base-url:http://localhost:8081}")
+@FeignClient(
+        name = "user-service",
+        url = "${external.user-service.base-url}",
+        configuration = UserServiceFeignConfig.class
+)
 public interface UserServiceClient {
 
-    @PostMapping("/internal/users")
-    void createUser(/* DTO interno futuro */);
+    @PostMapping(value = "/api/v1/usuarios", consumes = "application/json")
+    UsuarioResponse criar(@RequestBody CreateUsuarioRequest request);
 }

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/clients/UserServiceFeignAdapter.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/clients/UserServiceFeignAdapter.java
@@ -1,0 +1,21 @@
+package com.squadprisma.notesoccer.orchestration_service.infra.clients;
+
+import com.squadprisma.notesoccer.orchestration_service.api.dto.CreateUsuarioRequest;
+import com.squadprisma.notesoccer.orchestration_service.api.dto.UsuarioResponse;
+import com.squadprisma.notesoccer.orchestration_service.application.port.out.UserServicePort;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserServiceFeignAdapter implements UserServicePort {
+
+    private final UserServiceClient client;
+
+    public UserServiceFeignAdapter(UserServiceClient client){
+        this.client = client;
+    }
+
+    @Override
+    public UsuarioResponse criarUsuario(CreateUsuarioRequest request) {
+        return client.criar(request);
+    }
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/dispatcher/SagaDispatcherConfig.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/dispatcher/SagaDispatcherConfig.java
@@ -1,0 +1,23 @@
+package com.squadprisma.notesoccer.orchestration_service.infra.dispatcher;
+
+import com.squadprisma.notesoccer.orchestration_service.domain.port.SagaDispatcher;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SagaDispatcherConfig {
+
+    @Bean
+    @ConditionalOnProperty(name = "saga.enabled", havingValue = "true")
+    SagaDispatcher http(HttpSagaDispatcher d){
+        return d;
+    }
+
+    @Bean
+    @ConditionalOnProperty(name="saga.enabled", havingValue="false", matchIfMissing = true)
+    SagaDispatcher noop(NoopSagaDispatcher d){
+        return d;
+    }
+}
+

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/integrations/UserServiceFeignConfig.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/integrations/UserServiceFeignConfig.java
@@ -1,0 +1,19 @@
+package com.squadprisma.notesoccer.orchestration_service.integrations;
+
+import feign.RequestInterceptor;
+import org.springframework.context.annotation.Bean;
+
+import java.util.UUID;
+
+public class UserServiceFeignConfig {
+
+    @Bean
+    RequestInterceptor correlationId(){
+        return requestTemplate -> {
+            // gera / propaga um X-Correlation-Id simples
+            if (!requestTemplate.headers().containsKey("X-Correlation-Id")){
+                requestTemplate.header("X-Correlation-Id", UUID.randomUUID().toString());
+            }
+        };
+    }
+}

--- a/orchestration-service/src/main/resources/application-example.properties
+++ b/orchestration-service/src/main/resources/application-example.properties
@@ -3,6 +3,11 @@ spring.datasource.username=<USERNAME>
 spring.datasource.password=<PASSWORD>
 spring.datasource.driver-class-name=org.postgresql.Driver
 
+# USER SERVICE
+external.user-service.base-url=
+spring.cloud.openfeign.client.config.user-service.connectTimeout=15000
+spring.cloud.openfeign.client.config.user-service.readTimeout=60000
+
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect

--- a/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/application/service/UserOrchestrationServiceTest.java
+++ b/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/application/service/UserOrchestrationServiceTest.java
@@ -1,0 +1,125 @@
+package com.squadprisma.notesoccer.orchestration_service.application.service;
+
+import com.squadprisma.notesoccer.orchestration_service.api.dto.CreateUsuarioRequest;
+import com.squadprisma.notesoccer.orchestration_service.api.dto.UsuarioResponse;
+import com.squadprisma.notesoccer.orchestration_service.application.port.out.UserServicePort;
+import feign.FeignException;
+import feign.RetryableException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Testes unitários do caso de uso que integra com o user-service via porta (UserServicePort).
+ * Focamos em: sucesso, 409-CONFLICT, timeout/retryable (504) e erro genérico (502).
+ */
+@ExtendWith(MockitoExtension.class)
+public class UserOrchestrationServiceTest {
+
+    @Mock
+    UserServicePort userPort;
+
+    @InjectMocks
+    UserOrchestrationService service;
+
+    private CreateUsuarioRequest request;
+    private UsuarioResponse response;
+
+    @BeforeEach
+    void setup(){
+        request = new CreateUsuarioRequest(
+                "Leonardo",
+                "leonardo@exemplo2.com",
+                "12345678",
+                "Leo",
+                "+55 74 99813-1055"
+        );
+
+        response = new UsuarioResponse(
+                UUID.randomUUID(),
+                "Leonardo",
+                "leonardo@exemplo2.com",
+                "Leo",
+                "+55 74 99813-1055"
+        );
+    }
+
+    @Test
+    void criarUsuario_deveDelegarParaPorta_eRetornarResposta(){
+        // given
+        when(userPort.criarUsuario(request)).thenReturn(response);
+
+        // when
+        var out = service.criarUsuario(request);
+
+        //then
+        assertThat(out).isEqualTo(response);
+        verify(userPort, times(1)).criarUsuario(request);
+        verifyNoMoreInteractions(userPort);
+    }
+
+    @Test
+    void criarUsuario_deveMapear409ParaResponseStatusExceptionConflict(){
+        // given: simulamos um 409 do Feign
+        FeignException.Conflict conflict = mock(FeignException.Conflict.class);
+        when(conflict.contentUTF8()).thenReturn("EMAIL_ALREADY_EXISTS");
+        when(userPort.criarUsuario(any())).thenThrow(conflict);
+
+        // when
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.criarUsuario(request));
+
+        // then
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(ex.getReason()).isEqualTo("EMAIL_ALREADY_EXISTS");
+        verify(userPort).criarUsuario(request);
+        verifyNoMoreInteractions(userPort);
+    }
+
+    @Test
+    void criarUsuario_deveMapearRetryableExceptionPara504GatewayTimeout() {
+        // given: timeout/conexão (Feign lança RetryableException)
+        RetryableException retryable = mock(RetryableException.class);
+        when(userPort.criarUsuario(any())).thenThrow(retryable);
+
+        // when
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.criarUsuario(request));
+
+        // then
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.GATEWAY_TIMEOUT);
+        assertThat(ex.getReason()).isEqualTo("user-service timeout");
+        verify(userPort).criarUsuario(request);
+        verifyNoMoreInteractions(userPort);
+    }
+
+    @Test
+    void criarUsuario_deveMapearFeignGenericoPara502BadGateway() {
+        // given: erro genérico do Feign (ex.: 5xx qualquer)
+        FeignException generic = mock(FeignException.class);
+        when(generic.status()).thenReturn(503);
+        when(userPort.criarUsuario(any())).thenThrow(generic);
+
+        // when
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.criarUsuario(request));
+
+        // then
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_GATEWAY);
+        assertThat(ex.getReason()).isEqualTo("user-service error: 503");
+        verify(userPort).criarUsuario(request);
+        verifyNoMoreInteractions(userPort);
+    }
+}


### PR DESCRIPTION
Objetivo: Orquestrar criação de usuário via user-service.
Mudanças: Feign client, porta/adapter, caso de uso, controller, DTOs, props, testes, cleanup.
Env (Render): USER_SERVICE_BASE_URL=https://user-service-dev-ni01.onrender.com

Como testar:

```bash
curl -X POST "$ORCH_URL/orchestration/v1/usuarios" \
  -H "Content-Type: application/json" \
  -d '{"nome":"Leonardo","email":"leonardo@notesoccer2.com","senha":"12345678","apelido":"Leo","whatsapp":"+55 74 99813-1055"}'
``` 

Esperado: 201 e registro em user_dev.users.