### PR TITLE
feat: integração do League Service no Orchestration Service com teste…

### DIFF
--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/OrchestrationServiceApplication.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/OrchestrationServiceApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
-@EnableFeignClients(basePackages = "com.squadprisma.notesoccer.orchestration_service")
 @SpringBootApplication
 public class OrchestrationServiceApplication {
 

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationLigaController.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationLigaController.java
@@ -1,0 +1,53 @@
+package com.squadprisma.notesoccer.orchestration_service.api.controller;
+
+import com.squadprisma.notesoccer.orchestration_service.api.dto.*;
+import com.squadprisma.notesoccer.orchestration_service.application.service.LeagueOrchestrationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@Tag(name = "Ligas")
+@RestController
+@RequestMapping("/api/v1/orquestrador/ligas")
+@RequiredArgsConstructor
+public class OrchestrationLigaController {
+
+    private final LeagueOrchestrationService service;
+
+    @PostMapping
+    @Operation(summary = "Criar liga")
+    public ResponseEntity<LigaResponse> criarLiga(@Valid @RequestBody CreateLigaRequest body) {
+        var resp = service.criarLiga(body);
+        return ResponseEntity.status(HttpStatus.CREATED).body(resp);
+    }
+
+    @PostMapping("/{ligaId}/times")
+    @Operation(summary = "Criar time em uma liga")
+    public ResponseEntity<TimeResponse> criarTime(
+            @PathVariable UUID ligaId,
+            @Valid @RequestBody CreateTimeRequest body) {
+        var resp = service.criarTime(ligaId, body.nome()); // força o path como fonte da liga
+        return ResponseEntity.status(HttpStatus.CREATED).body(resp);
+    }
+
+    @GetMapping("/{ligaId}/times")
+    @Operation(summary = "Listar times por liga")
+    public PageResponse<TimeResponse> listarTimes(
+            @PathVariable UUID ligaId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return service.listarTimes(ligaId, page, size);
+    }
+
+    @GetMapping("/{ligaId}/times/count")
+    @Operation(summary = "Contar times por liga")
+    public TimeCountResponse contarTimes(@PathVariable UUID ligaId) {
+        return service.contarTimes(ligaId);
+    }
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationUsuarioController.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationUsuarioController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Usuarios")
 @RestController
-@RequestMapping("api/v1/orchestrador-usuarios")
+@RequestMapping("/api/v1/orquestrador/usuarios")
 public class OrchestrationUsuarioController {
 
     private final UserOrchestrationService service;

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/CreateLigaRequest.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/CreateLigaRequest.java
@@ -1,0 +1,10 @@
+package com.squadprisma.notesoccer.orchestration_service.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateLigaRequest(
+        @NotBlank @Size(min = 3, max = 80)
+        String nome
+) {
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/CreateTimeRequest.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/CreateTimeRequest.java
@@ -1,0 +1,14 @@
+package com.squadprisma.notesoccer.orchestration_service.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+public record CreateTimeRequest(
+        @NotNull UUID ligaId,
+        @NotBlank @Size(min = 3, max = 50)
+        String nome
+) {
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/CreateUsuarioRequest.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/CreateUsuarioRequest.java
@@ -1,5 +1,13 @@
 package com.squadprisma.notesoccer.orchestration_service.api.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
 //request
 public record CreateUsuarioRequest(
-        String nome, String email, String senha, String apelido, String whatsapp) {}
+        @NotBlank @Size(min = 3, max = 80)String nome,
+        @NotBlank @Email String email,
+        @NotBlank @Size(min = 8, max = 80) String senha,
+        @NotBlank @Size(min = 3, max = 40) String apelido,
+        @NotBlank @Size(min = 8, max = 30) String whatsapp) {}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/LigaResponse.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/LigaResponse.java
@@ -1,0 +1,11 @@
+package com.squadprisma.notesoccer.orchestration_service.api.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record LigaResponse(
+        UUID id,
+        String nome,
+        Instant createdAt
+) {
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/PageResponse.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/PageResponse.java
@@ -1,0 +1,12 @@
+package com.squadprisma.notesoccer.orchestration_service.api.dto;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/TimeCountResponse.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/TimeCountResponse.java
@@ -1,0 +1,9 @@
+package com.squadprisma.notesoccer.orchestration_service.api.dto;
+
+import java.util.UUID;
+
+public record TimeCountResponse(
+        UUID ligaId,
+        long count
+) {
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/TimeResponse.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/TimeResponse.java
@@ -1,0 +1,11 @@
+package com.squadprisma.notesoccer.orchestration_service.api.dto;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record TimeResponse(
+        UUID id,
+        UUID ligaId,
+        String nome,
+        Instant createdAt) {
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/exceptions/ApiExceptionHandler.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/exceptions/ApiExceptionHandler.java
@@ -11,13 +11,6 @@ import java.util.Map;
 @ControllerAdvice
 public class ApiExceptionHandler {
 
-    @ExceptionHandler(ResponseStatusException.class)
-    public ResponseEntity<?> handle(ResponseStatusException ex){
-        return ResponseEntity
-                .status(ex.getStatusCode())
-                .body(Map.of("error", ex.getReason()));
-    }
-
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<?> handle(MethodArgumentNotValidException ex){
         var errors = ex.getBindingResult().getFieldErrors()
@@ -29,5 +22,25 @@ public class ApiExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<?> handle(IllegalArgumentException ex){
         return ResponseEntity.badRequest().body(Map.of("error", ex.getMessage()));
+    }
+
+    @ExceptionHandler(ResponseStatusException.class)
+    public ResponseEntity<Map<String, Object>> handleResponseStatus(ResponseStatusException ex,
+                                                                    jakarta.servlet.http.HttpServletRequest req) {
+        var statusCode = ex.getStatusCode();               // HttpStatusCode
+        var httpStatus = (statusCode instanceof org.springframework.http.HttpStatus hs)
+                ? hs
+                : org.springframework.http.HttpStatus.resolve(statusCode.value());
+
+        String error = (httpStatus != null) ? httpStatus.getReasonPhrase() : "Unknown";
+
+        Map<String, Object> body = new java.util.LinkedHashMap<>();
+        body.put("timestamp", java.time.Instant.now().toString());
+        body.put("path", req.getRequestURI());
+        body.put("status", statusCode.value());
+        body.put("error", error);                          // ← aqui o "reason phrase"
+        body.put("message", ex.getReason());               // ← garante $.message
+
+        return org.springframework.http.ResponseEntity.status(statusCode).body(body);
     }
 }

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/application/port/out/LeagueServicePort.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/application/port/out/LeagueServicePort.java
@@ -1,0 +1,12 @@
+package com.squadprisma.notesoccer.orchestration_service.application.port.out;
+
+import com.squadprisma.notesoccer.orchestration_service.api.dto.*;
+
+import java.util.UUID;
+
+public interface LeagueServicePort {
+    LigaResponse criarLiga(CreateLigaRequest request);
+    TimeResponse criarTime(CreateTimeRequest request);
+    PageResponse<TimeResponse> listarTimes(UUID ligaId, int page, int size);
+    TimeCountResponse contarTimes(UUID ligaId);
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/application/service/LeagueOrchestrationService.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/application/service/LeagueOrchestrationService.java
@@ -1,0 +1,58 @@
+package com.squadprisma.notesoccer.orchestration_service.application.service;
+
+import com.squadprisma.notesoccer.orchestration_service.api.dto.*;
+import com.squadprisma.notesoccer.orchestration_service.application.port.out.LeagueServicePort;
+import feign.FeignException;
+import feign.RetryableException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+/**
+ * Orquestra as chamadas para o league-service.
+ * Faz o mapeamento de exceções Feign para ResponseStatusException, de forma
+ * padronizada e consistente com o UserOrchestrationService.
+ */
+@Service
+@RequiredArgsConstructor
+public class LeagueOrchestrationService {
+
+    private final LeagueServicePort port;
+
+    public LigaResponse criarLiga(CreateLigaRequest req) {
+        try {
+            return port.criarLiga(req);
+        } catch (FeignException.Conflict ex) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ex.contentUTF8());
+        } catch (RetryableException ex) {
+            throw new ResponseStatusException(HttpStatus.GATEWAY_TIMEOUT, "league-service timeout");
+        } catch (FeignException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "league-service error: " + ex.status());
+        }
+    }
+
+    public TimeResponse criarTime(UUID ligaId, String nome) {
+        try {
+            var req = new CreateTimeRequest(ligaId, nome);
+            return port.criarTime(req);
+        } catch (FeignException.Conflict ex) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ex.contentUTF8());
+        } catch (RetryableException ex) {
+            throw new ResponseStatusException(HttpStatus.GATEWAY_TIMEOUT, "league-service timeout");
+        } catch (FeignException ex) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "league-service error: " + ex.status());
+        }
+    }
+
+    public PageResponse<TimeResponse> listarTimes(UUID ligaId, int page, int size) {
+        // listagem normalmente não precisa de tratamento Feign específico
+        return port.listarTimes(ligaId, page, size);
+    }
+
+    public TimeCountResponse contarTimes(UUID ligaId) {
+        return port.contarTimes(ligaId);
+    }
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/application/service/UserOrchestrationService.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/application/service/UserOrchestrationService.java
@@ -5,18 +5,16 @@ import com.squadprisma.notesoccer.orchestration_service.api.dto.UsuarioResponse;
 import com.squadprisma.notesoccer.orchestration_service.application.port.out.UserServicePort;
 import feign.FeignException;
 import feign.RetryableException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 @Service
+@RequiredArgsConstructor
 public class UserOrchestrationService {
 
     private final UserServicePort userPort;
-
-    public UserOrchestrationService(UserServicePort userPort) {
-        this.userPort = userPort;
-    }
 
     public UsuarioResponse criarUsuario(CreateUsuarioRequest req) {
         try {

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/config/FeignClientsConfig.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/config/FeignClientsConfig.java
@@ -1,0 +1,11 @@
+package com.squadprisma.notesoccer.orchestration_service.config;
+
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile("!test") // não habilita Feign nos testes
+@Configuration
+@EnableFeignClients(basePackages = "com.squadprisma.notesoccer.orchestration_service")
+public class FeignClientsConfig {
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/clients/LeagueServiceClient.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/clients/LeagueServiceClient.java
@@ -1,0 +1,34 @@
+package com.squadprisma.notesoccer.orchestration_service.infra.clients;
+
+import com.squadprisma.notesoccer.orchestration_service.api.dto.*;
+import com.squadprisma.notesoccer.orchestration_service.integrations.LeagueServiceFeignConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.UUID;
+
+@FeignClient(
+        name = "league-service",
+        url = "${external.league-service.base-url}",
+        configuration = LeagueServiceFeignConfig.class
+)
+public interface LeagueServiceClient {
+    @PostMapping("/api/v1/ligas")
+    LigaResponse criarLiga(@RequestBody CreateLigaRequest body);
+
+    @PostMapping("/api/v1/times")
+    TimeResponse criarTime(@RequestBody CreateTimeRequest body);
+
+    @GetMapping("/api/v1/times")
+    PageResponse<TimeResponse> listarTimes(
+            @RequestParam("ligaId") UUID ligaId,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "20") int size
+    );
+
+    @GetMapping("/api/v1/times/count")
+    TimeCountResponse contarTimes(@RequestParam("ligaId") UUID ligaId);
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/clients/LeagueServiceFeignAdapter.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/clients/LeagueServiceFeignAdapter.java
@@ -1,0 +1,35 @@
+package com.squadprisma.notesoccer.orchestration_service.infra.clients;
+
+import com.squadprisma.notesoccer.orchestration_service.api.dto.*;
+import com.squadprisma.notesoccer.orchestration_service.application.port.out.LeagueServicePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class LeagueServiceFeignAdapter implements LeagueServicePort {
+
+    private final LeagueServiceClient client;
+
+    @Override
+    public LigaResponse criarLiga(CreateLigaRequest request) {
+        return client.criarLiga(request);
+    }
+
+    @Override
+    public TimeResponse criarTime(CreateTimeRequest request) {
+        return client.criarTime(request);
+    }
+
+    @Override
+    public PageResponse<TimeResponse> listarTimes(UUID ligaId, int page, int size) {
+        return client.listarTimes(ligaId, page, size);
+    }
+
+    @Override
+    public TimeCountResponse contarTimes(UUID ligaId) {
+        return client.contarTimes(ligaId);
+    }
+}

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/clients/UserServiceFeignAdapter.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/clients/UserServiceFeignAdapter.java
@@ -3,16 +3,14 @@ package com.squadprisma.notesoccer.orchestration_service.infra.clients;
 import com.squadprisma.notesoccer.orchestration_service.api.dto.CreateUsuarioRequest;
 import com.squadprisma.notesoccer.orchestration_service.api.dto.UsuarioResponse;
 import com.squadprisma.notesoccer.orchestration_service.application.port.out.UserServicePort;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class UserServiceFeignAdapter implements UserServicePort {
 
     private final UserServiceClient client;
-
-    public UserServiceFeignAdapter(UserServiceClient client){
-        this.client = client;
-    }
 
     @Override
     public UsuarioResponse criarUsuario(CreateUsuarioRequest request) {

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/integrations/LeagueServiceFeignConfig.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/integrations/LeagueServiceFeignConfig.java
@@ -1,0 +1,18 @@
+package com.squadprisma.notesoccer.orchestration_service.integrations;
+
+import feign.RequestInterceptor;
+import org.springframework.context.annotation.Bean;
+
+import java.util.UUID;
+
+public class LeagueServiceFeignConfig {
+
+    @Bean
+    RequestInterceptor correlationId(){
+        return requestTemplate -> {
+            if (!requestTemplate.headers().containsKey("X-Correlation-Id")) {
+                requestTemplate.header("X-Correlation-Id", UUID.randomUUID().toString());
+            }
+        };
+    }
+}

--- a/orchestration-service/src/main/resources/application.properties
+++ b/orchestration-service/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=orchestration-service
-spring.profiles.active=dev
+#spring.profiles.active=dev
 management.endpoints.web.exposure.include=health,info,metrics
 spring.main.web-application-type=servlet
 

--- a/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/OrchestrationServiceApplicationTests.java
+++ b/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/OrchestrationServiceApplicationTests.java
@@ -1,13 +1,37 @@
 package com.squadprisma.notesoccer.orchestration_service;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@SpringBootTest
+
+@ExtendWith(SpringExtension.class)
+@ActiveProfiles("test")
+@ContextConfiguration(classes = OrchestrationServiceApplicationTests.MinimalTestConfig.class)
 class OrchestrationServiceApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() { }
 
+    @Configuration
+    @EnableAutoConfiguration(exclude = {
+            DataSourceAutoConfiguration.class,
+            HibernateJpaAutoConfiguration.class,
+            org.springframework.cloud.openfeign.FeignAutoConfiguration.class,
+            SecurityAutoConfiguration.class,
+            SecurityFilterAutoConfiguration.class,
+            OAuth2ResourceServerAutoConfiguration.class
+    })
+    @Import(com.squadprisma.notesoccer.orchestration_service.api.exceptions.ApiExceptionHandler.class)
+    static class MinimalTestConfig { }
 }

--- a/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationLigaControllerTest.java
+++ b/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationLigaControllerTest.java
@@ -1,0 +1,131 @@
+package com.squadprisma.notesoccer.orchestration_service.api.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.squadprisma.notesoccer.orchestration_service.api.dto.*;
+import com.squadprisma.notesoccer.orchestration_service.api.exceptions.ApiExceptionHandler;
+import com.squadprisma.notesoccer.orchestration_service.application.service.LeagueOrchestrationService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.containsString;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.*;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = OrchestrationLigaController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(ApiExceptionHandler.class)
+@org.springframework.test.context.ActiveProfiles("test")
+public class OrchestrationLigaControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    ObjectMapper om;
+
+    @MockBean
+    LeagueOrchestrationService service;
+
+    @Test
+    void post_criar_liga_201() throws Exception {
+        var resp = new LigaResponse(UUID.randomUUID(), "Liga Zona Norte", Instant.now());
+        Mockito.when(service.criarLiga(any())).thenReturn(resp);
+
+        var body = new CreateLigaRequest("Liga Zona Norte");
+
+        mvc.perform(post("/api/v1/orquestrador/ligas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(body)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andExpect(jsonPath("$.nome").value("Liga Zona Norte"));
+    }
+
+    @Test
+    void post_criar_liga_400_validacao_nome_em_branco() throws Exception {
+        var body = new CreateLigaRequest("   "); // @NotBlank em DTO
+
+        mvc.perform(post("/api/v1/orquestrador/ligas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(body)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void post_criar_liga_409_mapeado_por_service() throws Exception {
+        Mockito.when(service.criarLiga(any()))
+                .thenThrow(new ResponseStatusException(CONFLICT, "LEAGUE_ALREADY_EXISTS"));
+
+        var body = new CreateLigaRequest("Liga X");
+
+        mvc.perform(post("/api/v1/orquestrador/ligas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(body)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message", containsString("LEAGUE_ALREADY_EXISTS")));
+    }
+
+    @Test
+    void post_criar_time_201_forca_ligaId_do_path() throws Exception {
+        var ligaId = UUID.randomUUID();
+        var resp = new TimeResponse(UUID.randomUUID(), ligaId, "Atlético Jardim", Instant.now());
+        Mockito.when(service.criarTime(eq(ligaId), anyString())).thenReturn(resp);
+
+        // Mesmo que o body tenha outro leagueId, controller usa o do path
+        var body = new CreateTimeRequest(UUID.randomUUID(), "Atlético Jardim");
+
+        mvc.perform(post("/api/v1/orquestrador/ligas/{ligaId}/times", ligaId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(body)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.ligaId").value(ligaId.toString()))
+                .andExpect(jsonPath("$.nome").value("Atlético Jardim"));
+    }
+
+    @Test
+    void get_listar_times_200() throws Exception {
+        var ligaId = UUID.randomUUID();
+        var t1 = new TimeResponse(UUID.randomUUID(), ligaId, "Time A", Instant.now());
+        var t2 = new TimeResponse(UUID.randomUUID(), ligaId, "Time B", Instant.now());
+        var page = new PageResponse<>(List.of(t1, t2), 0, 20, 2, 1);
+
+        Mockito.when(service.listarTimes(ligaId, 0, 20)).thenReturn(page);
+
+        mvc.perform(get("/api/v1/orquestrador/ligas/{ligaId}/times", ligaId)
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(2)))
+                .andExpect(jsonPath("$.totalElements").value(2));
+    }
+
+    @Test
+    void get_contar_times_200() throws Exception {
+        var ligaId = UUID.randomUUID();
+        var resp = new TimeCountResponse(ligaId, 7);
+        Mockito.when(service.contarTimes(ligaId)).thenReturn(resp);
+
+        mvc.perform(get("/api/v1/orquestrador/ligas/{ligaId}/times/count", ligaId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ligaId").value(ligaId.toString()))
+                .andExpect(jsonPath("$.count").value(7));
+    }
+}

--- a/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationUsuarioControllerTest.java
+++ b/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationUsuarioControllerTest.java
@@ -1,0 +1,89 @@
+package com.squadprisma.notesoccer.orchestration_service.api.controller;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.squadprisma.notesoccer.orchestration_service.api.dto.CreateUsuarioRequest;
+import com.squadprisma.notesoccer.orchestration_service.api.dto.UsuarioResponse;
+import com.squadprisma.notesoccer.orchestration_service.api.exceptions.ApiExceptionHandler;
+import com.squadprisma.notesoccer.orchestration_service.application.service.UserOrchestrationService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = OrchestrationUsuarioController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(ApiExceptionHandler.class)
+@org.springframework.test.context.ActiveProfiles("test")
+public class OrchestrationUsuarioControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    ObjectMapper om;
+
+    @MockBean
+    UserOrchestrationService service;
+
+    @Test
+    void post_criar_usuario_201() throws Exception {
+        var req = new CreateUsuarioRequest("Leonardo","leonardo@exemplo.com","12345678","Leo","+55 74 99999-9999");
+        var resp = new UsuarioResponse(UUID.randomUUID(),"Leonardo","leonardo@exemplo.com","Leo","+55 74 99999-9999");
+
+        Mockito.when(service.criarUsuario(any())).thenReturn(resp);
+
+        mvc.perform(post("/api/v1/orquestrador/usuarios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").isNotEmpty())
+                .andExpect(jsonPath("$.email").value("leonardo@exemplo.com"));
+    }
+
+    @Test
+    void post_criar_usuario_400_validacao() throws Exception {
+        // email inválido, senha curta, apelido vazio, whatsapp curto
+        var req = new CreateUsuarioRequest("L", "email-invalido", "123", "", "123");
+
+        mvc.perform(post("/api/v1/orquestrador/usuarios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void post_criar_usuario_409_mapeado_por_service() throws Exception {
+        var req = new CreateUsuarioRequest(
+                "Leonardo",                      // min 3
+                "existente@exemplo.com",         // email válido
+                "12345678",                      // min 8
+                "Leo",                           // min 3
+                "+55 11 99999-9999"              // 8..30 (este cumpre)
+        );
+
+        Mockito.when(service.criarUsuario(any()))
+                .thenThrow(new ResponseStatusException(CONFLICT, "EMAIL_ALREADY_EXISTS"));
+
+        mvc.perform(post("/api/v1/orquestrador/usuarios")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message", containsString("EMAIL_ALREADY_EXISTS")));
+    }
+}

--- a/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/application/service/LeagueOrchestrationServiceTest.java
+++ b/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/application/service/LeagueOrchestrationServiceTest.java
@@ -1,0 +1,199 @@
+package com.squadprisma.notesoccer.orchestration_service.application.service;
+
+import com.squadprisma.notesoccer.orchestration_service.api.dto.*;
+import com.squadprisma.notesoccer.orchestration_service.application.port.out.LeagueServicePort;
+import feign.FeignException;
+import feign.RetryableException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+/**
+ * Testes unitários do caso de uso que integra com o league-service via porta (LeagueServicePort).
+ * Cenários cobertos:
+ *  - Sucesso
+ *  - 409 (duplicidade) mapeado para ResponseStatusException CONFLICT
+ *  - RetryableException (timeout/conexão) mapeado para 504 GATEWAY_TIMEOUT
+ *  - Feign genérico 5xx mapeado para 502 BAD_GATEWAY
+ */
+@ExtendWith(MockitoExtension.class)
+public class LeagueOrchestrationServiceTest {
+
+    @Mock
+    LeagueServicePort port;
+
+    @InjectMocks
+    LeagueOrchestrationService service;
+
+    private CreateLigaRequest ligaReq;
+    private LigaResponse ligaResp;
+
+    private UUID ligaId;
+    private String timeNome;
+    private TimeResponse timeResp;
+
+    @BeforeEach
+    void setup() {
+        ligaReq = new CreateLigaRequest("Liga Zona Norte");
+        ligaResp = new LigaResponse(UUID.randomUUID(), "Liga Zona Norte", Instant.now());
+
+        ligaId = UUID.randomUUID();
+        timeNome = "Atlético Jardim";
+        timeResp = new TimeResponse(UUID.randomUUID(), ligaId, timeNome, Instant.now());
+    }
+
+    // ====== criarLiga ======
+
+    @Test
+    void criarLiga_deveDelegarParaPorta_eRetornarResposta() {
+        when(port.criarLiga(ligaReq)).thenReturn(ligaResp);
+
+        var out = service.criarLiga(ligaReq);
+
+        assertThat(out).isEqualTo(ligaResp);
+        verify(port).criarLiga(ligaReq);
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void criarLiga_deveMapear409ParaResponseStatusExceptionConflict() {
+        FeignException.Conflict conflict = mock(FeignException.Conflict.class);
+        when(conflict.contentUTF8()).thenReturn("LEAGUE_ALREADY_EXISTS");
+        when(port.criarLiga(any())).thenThrow(conflict);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.criarLiga(ligaReq));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(ex.getReason()).isEqualTo("LEAGUE_ALREADY_EXISTS");
+        verify(port).criarLiga(ligaReq);
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void criarLiga_deveMapearRetryableExceptionPara504GatewayTimeout() {
+        RetryableException retryable = mock(RetryableException.class);
+        when(port.criarLiga(any())).thenThrow(retryable);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.criarLiga(ligaReq));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.GATEWAY_TIMEOUT);
+        assertThat(ex.getReason()).isEqualTo("league-service timeout");
+        verify(port).criarLiga(ligaReq);
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void criarLiga_deveMapearFeignGenericoPara502BadGateway() {
+        FeignException generic = mock(FeignException.class);
+        when(generic.status()).thenReturn(503);
+        when(port.criarLiga(any())).thenThrow(generic);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.criarLiga(ligaReq));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_GATEWAY);
+        assertThat(ex.getReason()).isEqualTo("league-service error: 503");
+        verify(port).criarLiga(ligaReq);
+        verifyNoMoreInteractions(port);
+    }
+
+    // ====== criarTime ======
+
+    @Test
+    void criarTime_deveDelegarParaPorta_eRetornarResposta() {
+        // service.criarTime monta CreateTimeRequest(ligaId, nome) e delega
+        when(port.criarTime(any(CreateTimeRequest.class))).thenReturn(timeResp);
+
+        var out = service.criarTime(ligaId, timeNome);
+
+        assertThat(out).isEqualTo(timeResp);
+        verify(port).criarTime(argThat(req ->
+                req.ligaId().equals(ligaId) && req.nome().equals(timeNome)));
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void criarTime_deveMapear409ParaResponseStatusExceptionConflict() {
+        FeignException.Conflict conflict = mock(FeignException.Conflict.class);
+        when(conflict.contentUTF8()).thenReturn("TEAM_ALREADY_EXISTS");
+        when(port.criarTime(any())).thenThrow(conflict);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.criarTime(ligaId, timeNome));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(ex.getReason()).isEqualTo("TEAM_ALREADY_EXISTS");
+        verify(port).criarTime(any());
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void criarTime_deveMapearRetryableExceptionPara504GatewayTimeout() {
+        RetryableException retryable = mock(RetryableException.class);
+        when(port.criarTime(any())).thenThrow(retryable);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.criarTime(ligaId, timeNome));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.GATEWAY_TIMEOUT);
+        assertThat(ex.getReason()).isEqualTo("league-service timeout");
+        verify(port).criarTime(any());
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void criarTime_deveMapearFeignGenericoPara502BadGateway() {
+        FeignException generic = mock(FeignException.class);
+        when(generic.status()).thenReturn(502);
+        when(port.criarTime(any())).thenThrow(generic);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.criarTime(ligaId, timeNome));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_GATEWAY);
+        assertThat(ex.getReason()).isEqualTo("league-service error: 502");
+        verify(port).criarTime(any());
+        verifyNoMoreInteractions(port);
+    }
+
+    // ====== listar/contar (sucesso) ======
+
+    @Test
+    void listarTimes_deveDelegarParaPorta() {
+        var page = new PageResponse<TimeResponse>(List.of(timeResp), 0, 20, 1, 1);
+        when(port.listarTimes(ligaId, 0, 20)).thenReturn(page);
+
+        var out = service.listarTimes(ligaId, 0, 20);
+
+        assertThat(out.totalElements()).isEqualTo(1);
+        verify(port).listarTimes(ligaId, 0, 20);
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void contarTimes_deveDelegarParaPorta() {
+        var count = new TimeCountResponse(ligaId, 1);
+        when(port.contarTimes(ligaId)).thenReturn(count);
+
+        var out = service.contarTimes(ligaId);
+
+        assertThat(out.count()).isEqualTo(1);
+        verify(port).contarTimes(ligaId);
+        verifyNoMoreInteractions(port);
+    }
+}

--- a/orchestration-service/src/test/resources/application-test.properties
+++ b/orchestration-service/src/test/resources/application-test.properties
@@ -1,0 +1,21 @@
+spring.application.name=orchestration-service-test
+spring.main.web-application-type=servlet
+
+# Desliga integrações/infra
+spring.cloud.openfeign.enabled=false
+spring.autoconfigure.exclude=\
+  org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration,\
+  org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration,\
+  org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration,\
+  org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration,\
+  org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration
+
+spring.flyway.enabled=false
+spring.jpa.hibernate.ddl-auto=none
+
+# SpringDoc OFF em teste
+springdoc.api-docs.enabled=false
+springdoc.swagger-ui.enabled=false
+
+external.user-service.base-url=http://localhost:18081
+external.league-service.base-url=http://localhost:18082

--- a/orchestration-service/src/test/resources/application.properties
+++ b/orchestration-service/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.profiles.active=test


### PR DESCRIPTION
Este PR implementa a integração completa do League Service com o Orchestration Service, permitindo que o orquestrador coordene chamadas para o microserviço de ligas e times.

Foram criados os fluxos principais via Feign Client e controladores REST documentados com Swagger, além da adição de testes unitários para todos os cenários críticos.

Adicionada a classe LeagueOrchestrationService com tratamento padronizado de exceções Feign.

Criado o controller OrchestrationLigaController com endpoints:

POST /api/v1/orquestrador/ligas — criação de ligas
POST /api/v1/orquestrador/ligas/{ligaId}/times — criação de times
GET /api/v1/orquestrador/ligas/{ligaId}/times — listagem paginada de times
GET /api/v1/orquestrador/ligas/{ligaId}/times/count — contagem de times

Configurada a integração Feign com LeagueServicePort e LeagueServiceFeignConfig.

Padronizado o tratamento de erros no ApiExceptionHandler (incluindo campo $.message).

Adicionados testes unitários para:
- LeagueOrchestrationService
- OrchestrationLigaController
- UserOrchestrationService
- OrchestrationUsuarioController