### PR TITLE
Feature: Criação do microserviço Match-Service (Partidas)

### DIFF
--- a/league-service/pom.xml
+++ b/league-service/pom.xml
@@ -47,7 +47,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/match-service/Dockerfile
+++ b/match-service/Dockerfile
@@ -1,0 +1,17 @@
+# ==== Stage 1: build ====
+FROM maven:3.9.7-eclipse-temurin-21 AS build
+WORKDIR /repo
+
+# Copia o repo inteiro porque o módulo usa POM pai e pode depender de shared-libs
+# (use .dockerignore para não mandar target/, .git/, etc)
+COPY . .
+
+# Builda apenas o módulo orchestration-service e seus dependentes (-am), sem testes
+RUN mvn -q -e -DskipTests -f match-service/pom.xml clean package spring-boot:repackage
+
+# ==== Stage 2: runtime ====
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /repo/match-service/target/*.jar /app/app.jar
+EXPOSE 8080
+ENTRYPOINT ["sh","-c","java -Dserver.port=$PORT -Dspring.profiles.active=$SPRING_PROFILES_ACTIVE -jar /app/app.jar"]

--- a/match-service/pom.xml
+++ b/match-service/pom.xml
@@ -34,6 +34,11 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
@@ -42,13 +47,36 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.8.13</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/match-service/src/main/java/com/squadprisma/notesoccer/match_service/api/controller/PartidaController.java
+++ b/match-service/src/main/java/com/squadprisma/notesoccer/match_service/api/controller/PartidaController.java
@@ -1,0 +1,56 @@
+package com.squadprisma.notesoccer.match_service.api.controller;
+
+import com.squadprisma.notesoccer.match_service.api.dto.PartidaRequest;
+import com.squadprisma.notesoccer.match_service.api.dto.PartidaResponse;
+import com.squadprisma.notesoccer.match_service.domain.entity.Partida;
+import com.squadprisma.notesoccer.match_service.domain.enums.PartidaStatus;
+import com.squadprisma.notesoccer.match_service.service.PartidaService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/partidas")
+@RequiredArgsConstructor
+@Tag(name = "Partidas")
+public class PartidaController {
+
+    private final PartidaService service;
+
+    @PostMapping
+    @Operation(summary = "Criar uma Partida")
+    public PartidaResponse criar(@RequestBody @Valid PartidaRequest req){
+        Partida p = Partida.builder()
+                .ligaId(req.ligaId())
+                .casaTimeId(req.casaTimeId())
+                .visitanteTimeId((req.visitanteTimeId()))
+                .startAt(req.startAt())
+                .endAt(req.endAt())
+                .local(req.local())
+                .notas(req.notas())
+                .status(PartidaStatus.AGENDADA)
+                .build();
+        return toDto(service.criar(p));
+    }
+
+    @GetMapping("/calendario")
+    @Operation(summary = "Consultar as partidas de uma liga entre um intervalo de datas")
+    public List<PartidaResponse> calendario(@RequestParam UUID ligaId,
+                                            @RequestParam OffsetDateTime from,
+                                            @RequestParam OffsetDateTime to){
+        return service.calendario(ligaId, from, to).stream().map(this::toDto).toList();
+    }
+
+    private PartidaResponse toDto(Partida p){
+        return new PartidaResponse(
+                p.getId(), p.getLigaId(), p.getCasaTimeId(), p.getVisitanteTimeId(),
+                p.getStartAt(), p.getEndAt(), p.getLocal(), p.getNotas(), p.getStatus()
+        );
+    }
+}

--- a/match-service/src/main/java/com/squadprisma/notesoccer/match_service/api/dto/PartidaRequest.java
+++ b/match-service/src/main/java/com/squadprisma/notesoccer/match_service/api/dto/PartidaRequest.java
@@ -1,0 +1,17 @@
+package com.squadprisma.notesoccer.match_service.api.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record PartidaRequest(
+        @NotNull UUID ligaId,
+        @NotNull UUID casaTimeId,
+        @NotNull UUID visitanteTimeId,
+        @NotNull OffsetDateTime startAt,
+        @NotNull OffsetDateTime endAt,
+        String local,
+        String notas
+) {
+}

--- a/match-service/src/main/java/com/squadprisma/notesoccer/match_service/api/dto/PartidaResponse.java
+++ b/match-service/src/main/java/com/squadprisma/notesoccer/match_service/api/dto/PartidaResponse.java
@@ -1,0 +1,13 @@
+package com.squadprisma.notesoccer.match_service.api.dto;
+
+import com.squadprisma.notesoccer.match_service.domain.enums.PartidaStatus;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record PartidaResponse(
+        UUID id, UUID ligaId, UUID casaTimeId, UUID visitanteTimeId,
+        OffsetDateTime startAt, OffsetDateTime endAt,
+        String local, String notes, PartidaStatus status
+) {
+}

--- a/match-service/src/main/java/com/squadprisma/notesoccer/match_service/api/handler/GlobalExceptionHandler.java
+++ b/match-service/src/main/java/com/squadprisma/notesoccer/match_service/api/handler/GlobalExceptionHandler.java
@@ -1,0 +1,66 @@
+package com.squadprisma.notesoccer.match_service.api.handler;
+
+import com.squadprisma.notesoccer.match_service.domain.exception.ConflictException;
+import com.squadprisma.notesoccer.match_service.domain.exception.NotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private Map<String, Object> body(HttpStatus status, String code, String message, HttpServletRequest req) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("timestamp", Instant.now().toString());
+        m.put("status", status.value());
+        m.put("error", status.getReasonPhrase());
+        m.put("code", code);
+        m.put("message", message);
+        m.put("path", req.getRequestURI());
+        return m;
+    }
+    // 409 - conflito (suporta ConflictException e IllegalStateException do Java)
+    @ExceptionHandler({ConflictException.class, IllegalStateException.class})
+    @ResponseStatus(HttpStatus.CONFLICT)
+    Map<String, Object> handleConflict(RuntimeException ex, HttpServletRequest req) {
+        return body(HttpStatus.CONFLICT, ex.getMessage(), ex.getMessage(), req);
+    }
+
+    // 404
+    @ExceptionHandler(NotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    Map<String, Object> handleNotFound(NotFoundException ex, HttpServletRequest req) {
+        return body(HttpStatus.NOT_FOUND, ex.getMessage(), ex.getMessage(), req);
+    }
+
+    // 400 - validação bean
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    Map<String, Object> handleValidation(MethodArgumentNotValidException ex, HttpServletRequest req) {
+        String msg = ex.getBindingResult().getFieldErrors().stream()
+                .findFirst().map(e -> e.getField() + ": " + e.getDefaultMessage())
+                .orElse("Validation error");
+        return body(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", msg, req);
+    }
+
+    // 400 - entrada inválida
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    Map<String, Object> handleBadRequest(IllegalArgumentException ex, HttpServletRequest req) {
+        return body(HttpStatus.BAD_REQUEST, ex.getMessage(), ex.getMessage(), req);
+    }
+
+    // 500 - fallback
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    Map<String, Object> handleRuntime(RuntimeException ex, HttpServletRequest req) {
+        return body(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "Erro inesperado", req);
+    }
+}

--- a/match-service/src/main/java/com/squadprisma/notesoccer/match_service/domain/entity/Partida.java
+++ b/match-service/src/main/java/com/squadprisma/notesoccer/match_service/domain/entity/Partida.java
@@ -1,0 +1,55 @@
+package com.squadprisma.notesoccer.match_service.domain.entity;
+
+import com.squadprisma.notesoccer.match_service.domain.enums.PartidaStatus;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "partidas", schema = "match_dev")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Partida {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(nullable=false)
+    private UUID ligaId;
+
+    @Column(nullable=false)
+    private UUID casaTimeId;
+
+    @Column(nullable=false)
+    private UUID visitanteTimeId;
+
+    @Column(nullable=false)
+    private OffsetDateTime startAt;
+
+    @Column(nullable=false)
+    private OffsetDateTime endAt;
+
+    private String local;
+
+    private String notas;
+
+    private UUID createdBy;
+
+    @Column(nullable = false)
+    private PartidaStatus status;
+
+    @Column(nullable=false)
+    private OffsetDateTime createdAt = OffsetDateTime.now();
+
+    @Column(nullable=false)
+    private OffsetDateTime updatedAt = OffsetDateTime.now();
+
+    @PreUpdate
+    void onUpdate(){ this.updatedAt = OffsetDateTime.now();}
+}

--- a/match-service/src/main/java/com/squadprisma/notesoccer/match_service/domain/enums/PartidaStatus.java
+++ b/match-service/src/main/java/com/squadprisma/notesoccer/match_service/domain/enums/PartidaStatus.java
@@ -1,0 +1,5 @@
+package com.squadprisma.notesoccer.match_service.domain.enums;
+
+public enum PartidaStatus {
+    AGENDADA, ATUALIZADA, CANCELADA, FINALIZADA
+}

--- a/match-service/src/main/java/com/squadprisma/notesoccer/match_service/domain/exception/BadRequestException.java
+++ b/match-service/src/main/java/com/squadprisma/notesoccer/match_service/domain/exception/BadRequestException.java
@@ -1,0 +1,5 @@
+package com.squadprisma.notesoccer.match_service.domain.exception;
+
+public class BadRequestException extends RuntimeException{
+    public BadRequestException(String code) { super(code); }
+}

--- a/match-service/src/main/java/com/squadprisma/notesoccer/match_service/domain/exception/ConflictException.java
+++ b/match-service/src/main/java/com/squadprisma/notesoccer/match_service/domain/exception/ConflictException.java
@@ -1,0 +1,5 @@
+package com.squadprisma.notesoccer.match_service.domain.exception;
+
+public class ConflictException extends RuntimeException{
+    public ConflictException(String code) { super(code); }
+}

--- a/match-service/src/main/java/com/squadprisma/notesoccer/match_service/domain/exception/NotFoundException.java
+++ b/match-service/src/main/java/com/squadprisma/notesoccer/match_service/domain/exception/NotFoundException.java
@@ -1,0 +1,5 @@
+package com.squadprisma.notesoccer.match_service.domain.exception;
+
+public class NotFoundException extends RuntimeException{
+    public NotFoundException(String code) { super(code);}
+}

--- a/match-service/src/main/java/com/squadprisma/notesoccer/match_service/repository/PartidaRepository.java
+++ b/match-service/src/main/java/com/squadprisma/notesoccer/match_service/repository/PartidaRepository.java
@@ -1,0 +1,23 @@
+package com.squadprisma.notesoccer.match_service.repository;
+
+import com.squadprisma.notesoccer.match_service.domain.entity.Partida;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface PartidaRepository extends JpaRepository<Partida, UUID> {
+
+    @Query("""
+    select p from Partida p
+     where p.ligaId = :ligaId
+       and (p.casaTimeId in (:casaTimeId, :visitanteTimeId) or p.visitanteTimeId in (:casaTimeId, :visitanteTimeId))
+       and p.startAt < :endAt and p.endAt > :startAt
+  """)
+    List<Partida> findConflicts(UUID ligaId, UUID casaTimeId, UUID visitanteTimeId,
+                                OffsetDateTime startAt, OffsetDateTime endAt);
+
+    List<Partida> findByLigaIdAndStartAtBetween(UUID ligaId, OffsetDateTime from, OffsetDateTime to);
+}

--- a/match-service/src/main/java/com/squadprisma/notesoccer/match_service/service/PartidaService.java
+++ b/match-service/src/main/java/com/squadprisma/notesoccer/match_service/service/PartidaService.java
@@ -1,0 +1,40 @@
+package com.squadprisma.notesoccer.match_service.service;
+
+import com.squadprisma.notesoccer.match_service.domain.entity.Partida;
+import com.squadprisma.notesoccer.match_service.domain.exception.ConflictException;
+import com.squadprisma.notesoccer.match_service.repository.PartidaRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PartidaService {
+
+    private final PartidaRepository repo;
+
+    @Transactional
+    public Partida criar(Partida p){
+        if (p.getCasaTimeId().equals(p.getVisitanteTimeId()))
+            throw new IllegalArgumentException("Times devem ser distintos");
+
+        if (!p.getStartAt().isBefore(p.getEndAt()))
+            throw new IllegalArgumentException("Horário inválido");
+
+        List<Partida> conflicts = repo.findConflicts(
+                p.getLigaId(), p.getCasaTimeId(), p.getVisitanteTimeId(), p.getStartAt(), p.getEndAt());
+
+        if (!conflicts.isEmpty())
+            throw new IllegalStateException("Conflito de agenda");
+
+        return repo.save(p);
+    }
+
+    public List<Partida> calendario(UUID ligaId, OffsetDateTime from, OffsetDateTime to){
+        return repo.findByLigaIdAndStartAtBetween(ligaId, from, to);
+    }
+}

--- a/match-service/src/main/resources/application-example.properties
+++ b/match-service/src/main/resources/application-example.properties
@@ -1,0 +1,11 @@
+spring.datasource.url=jdbc:postgresql://<HOST>:<PORT>/<DB_NAME>
+spring.datasource.username=<USERNAME>
+spring.datasource.password=<PASSWORD>
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.properties.hibernate.default_schema=<SCHEMA>
+
+spring.flyway.enabled=false

--- a/match-service/src/main/resources/application.properties
+++ b/match-service/src/main/resources/application.properties
@@ -1,1 +1,16 @@
 spring.application.name=match-service
+spring.profiles.active=dev
+management.endpoints.web.exposure.include=health,info,metrics
+
+spring.jpa.open-in-view=false
+
+# Habilita Swagger UI
+springdoc.api-docs.enabled=true
+springdoc.swagger-ui.enabled=true
+springdoc.swagger-ui.path=/swagger-ui.html
+
+# log para ver se o springdoc ligou
+logging.level.org.springdoc=INFO
+
+spring.mvc.throw-exception-if-no-handler-found=true
+spring.web.resources.add-mappings=false

--- a/match-service/src/test/java/com/squadprisma/notesoccer/match_service/api/controller/PartidaControllerTest.java
+++ b/match-service/src/test/java/com/squadprisma/notesoccer/match_service/api/controller/PartidaControllerTest.java
@@ -1,0 +1,125 @@
+package com.squadprisma.notesoccer.match_service.api.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.squadprisma.notesoccer.match_service.api.dto.PartidaRequest;
+import com.squadprisma.notesoccer.match_service.domain.entity.Partida;
+import com.squadprisma.notesoccer.match_service.domain.enums.PartidaStatus;
+import com.squadprisma.notesoccer.match_service.service.PartidaService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(PartidaController.class)
+public class PartidaControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Autowired
+    ObjectMapper om;
+
+    @MockBean
+    PartidaService service;
+
+    private Partida mockPartida() {
+        Partida p = Partida.builder()
+                .id(UUID.randomUUID())
+                .ligaId(UUID.randomUUID())
+                .casaTimeId(UUID.randomUUID())
+                .visitanteTimeId(UUID.randomUUID())
+                .startAt(OffsetDateTime.parse("2025-07-22T09:00:00-03:00"))
+                .endAt(OffsetDateTime.parse("2025-07-22T10:30:00-03:00"))
+                .local("Quadra A")
+                .notas("Levar coletes")
+                .status(PartidaStatus.AGENDADA)
+                .build();
+        return p;
+    }
+
+    @Test
+    void create_returns_200_with_body() throws Exception {
+        Partida saved = mockPartida();
+        Mockito.when(service.criar(any(Partida.class))).thenReturn(saved);
+
+        PartidaRequest req = new PartidaRequest(
+                saved.getLigaId(), saved.getCasaTimeId(), saved.getVisitanteTimeId(),
+                saved.getStartAt(), saved.getEndAt(), "Quadra A", "Levar coletes");
+
+        mvc.perform(post("/api/v1/partidas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id", notNullValue()))
+                .andExpect(jsonPath("$.status", is("AGENDADA")))
+                .andExpect(jsonPath("$.local", is("Quadra A")));
+    }
+
+    @Test
+    void create_returns_409_on_conflict() throws Exception {
+        Mockito.when(service.criar(any(Partida.class))).thenThrow(new IllegalStateException("Conflito de agenda"));
+
+        PartidaRequest req = new PartidaRequest(
+                UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+                OffsetDateTime.parse("2025-07-22T09:00:00-03:00"),
+                OffsetDateTime.parse("2025-07-22T10:30:00-03:00"),
+                null, null);
+
+        mvc.perform(post("/api/v1/partidas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isConflict());
+    }
+
+    @Test
+    void create_returns_400_on_business_validation() throws Exception {
+        Mockito.when(service.criar(any(Partida.class))).thenThrow(new IllegalArgumentException("Horário inválido"));
+
+        PartidaRequest req = new PartidaRequest(
+                UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID(),
+                OffsetDateTime.parse("2025-07-22T10:30:00-03:00"),
+                OffsetDateTime.parse("2025-07-22T09:00:00-03:00"),
+                null, null);
+
+        mvc.perform(post("/api/v1/partidas")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(om.writeValueAsString(req)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void calendar_returns_list() throws Exception {
+        Partida p = mockPartida();
+        Mockito.when(service.calendario(any(), any(), any())).thenReturn(List.of(p));
+
+        UUID ligaId = p.getLigaId();
+        String from = "2025-07-01T00:00:00-03:00";
+        String to   = "2025-07-31T23:59:59-03:00";
+
+        mvc.perform(get("/api/v1/partidas/calendario")
+                        .param("ligaId", ligaId.toString())
+                        .param("from", from)
+                        .param("to", to))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].ligaId", is(ligaId.toString())))
+                .andExpect(jsonPath("$[0].status", is("AGENDADA")));
+    }
+
+
+}

--- a/match-service/src/test/java/com/squadprisma/notesoccer/match_service/service/PartidaServiceTest.java
+++ b/match-service/src/test/java/com/squadprisma/notesoccer/match_service/service/PartidaServiceTest.java
@@ -1,0 +1,110 @@
+package com.squadprisma.notesoccer.match_service.service;
+
+import com.squadprisma.notesoccer.match_service.domain.entity.Partida;
+import com.squadprisma.notesoccer.match_service.domain.enums.PartidaStatus;
+import com.squadprisma.notesoccer.match_service.repository.PartidaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+public class PartidaServiceTest {
+
+    private PartidaRepository repo;
+    private PartidaService service;
+
+    private final UUID ligaId = UUID.randomUUID();
+    private final UUID casaTimeId = UUID.randomUUID();
+    private final UUID visitanteTimeId = UUID.randomUUID();
+    private final OffsetDateTime start = OffsetDateTime.parse("2025-07-22T09:00:00-03:00");
+    private final OffsetDateTime end   = OffsetDateTime.parse("2025-07-22T10:30:00-03:00");
+
+    @BeforeEach
+    void setUp() {
+        repo = mock(PartidaRepository.class);
+        service = new PartidaService(repo);
+    }
+
+    private Partida buildPartida() {
+        Partida p = Partida.builder()
+                .ligaId(ligaId)
+                .casaTimeId(casaTimeId)
+                .visitanteTimeId(visitanteTimeId)
+                .startAt(start)
+                .endAt(end)
+                .local("Quadra A")
+                .notas("Levar coletes")
+                .status(PartidaStatus.AGENDADA)
+                .build();
+        return p;
+    }
+
+    @Test
+    void create_ok_saves_when_no_conflict() {
+        Partida toSave = buildPartida();
+        Partida saved = buildPartida();
+        saved.setId(UUID.randomUUID());
+        when(repo.findConflicts(ligaId, casaTimeId, visitanteTimeId, start, end)).thenReturn(List.of());
+        when(repo.save(any(Partida.class))).thenReturn(saved);
+
+        Partida result = service.criar(toSave);
+
+        // verifica chamada de conflito e persistência
+        verify(repo).findConflicts(ligaId, casaTimeId, visitanteTimeId, start, end);
+        ArgumentCaptor<Partida> cap = ArgumentCaptor.forClass(Partida.class);
+        verify(repo).save(cap.capture());
+
+        assertThat(result.getId()).isNotNull();
+        assertThat(cap.getValue().getStatus()).isEqualTo(PartidaStatus.AGENDADA);
+    }
+
+    @Test
+    void create_throws_when_same_team() {
+        Partida p = buildPartida();
+        p.setVisitanteTimeId(p.getCasaTimeId());
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> service.criar(p));
+        assertThat(ex.getMessage()).contains("Times devem ser distintos");
+        verifyNoInteractions(repo);
+    }
+
+    @Test
+    void create_throws_when_invalid_time_range() {
+        Partida p = buildPartida();
+        p.setEndAt(p.getStartAt());
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> service.criar(p));
+        assertThat(ex.getMessage()).contains("Horário inválido");
+        verifyNoInteractions(repo);
+    }
+
+    @Test
+    void create_throws_on_conflict() {
+        Partida p = buildPartida();
+        when(repo.findConflicts(ligaId, casaTimeId, visitanteTimeId, start, end)).thenReturn(List.of(new Partida()));
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> service.criar(p));
+        assertThat(ex.getMessage()).contains("Conflito de agenda");
+        verify(repo, never()).save(any());
+    }
+
+    @Test
+    void calendar_returns_items_from_repo() {
+        OffsetDateTime from = OffsetDateTime.parse("2025-07-01T00:00:00-03:00");
+        OffsetDateTime to   = OffsetDateTime.parse("2025-07-31T23:59:59-03:00");
+
+        when(repo.findByLigaIdAndStartAtBetween(ligaId, from, to)).thenReturn(List.of(buildPartida()));
+
+        var list = service.calendario(ligaId, from, to);
+
+        assertThat(list).hasSize(1);
+        verify(repo).findByLigaIdAndStartAtBetween(ligaId, from, to);
+    }
+}


### PR DESCRIPTION
Este PR implementa o novo microserviço Match-Service (Partidas), responsável por gerenciar o agendamento de partidas no ecossistema NoteSoccer.
Foram desenvolvidas as seguintes entregas:

- Estrutura inicial do serviço (feature/match-service-bootstrap)
- CRUD básico de Partidas (criação e consulta de calendário)
- Implementação de regras de negócio
    - Validação de times distintos
    - Validação de intervalo de horários
    - Prevenção de conflito de agenda

- Camadas Controller, Service e Repository concluídas
- Handler global de exceções padronizado (GlobalExceptionHandler)
- Testes unitários de Service e Controller implementados e aprovados
    - PartidaServiceTest
    - PartidaControllerTest
 
Integração com Supabase configurada (schema: match_dev)
Build e testes validados com sucesso

Próximos passos:

- Integração com o Orchestration-Service via endpoint /orchestration/partidas
- Implementar persistência de status e atualização de partidas