### PR TITLE
Associação de Liga ao Usuário (league-user-association)

### DIFF
--- a/league-service/src/main/java/com/squadprisma/notesoccer/league_service/api/controller/LigaController.java
+++ b/league-service/src/main/java/com/squadprisma/notesoccer/league_service/api/controller/LigaController.java
@@ -6,6 +6,9 @@ import com.squadprisma.notesoccer.league_service.domain.entity.Liga;
 import com.squadprisma.notesoccer.league_service.service.LigaService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,6 +16,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/ligas")
@@ -24,9 +29,27 @@ public class LigaController {
 
     @PostMapping
     @Operation(summary = "Criar uma nova liga")
-    public ResponseEntity<LigaResponse> create(@Valid @RequestBody LigaCreateRequest body) {
-        Liga l = service.create(body);
+    public ResponseEntity<LigaResponse> criar(@Valid @RequestBody LigaCreateRequest body) {
+        Liga l = service.criar(body);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(new LigaResponse(l.getId(), l.getNome(), l.getCreatedAt()));
+                .body(new LigaResponse(l.getId(), l.getNome(), l.getUserId(), l.getCreatedAt()));
     }
+
+    @Operation(summary = "Listar ligas por usuário")
+    @GetMapping
+    public Page<LigaResponse> listarPorUsuario(
+            @RequestParam UUID userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ){
+        var p = service.listarPorUsuario(userId, PageRequest.of(page, size))
+                .map(LigaController::toResponse);
+        return new PageImpl<>(p.getContent(), p.getPageable(), p.getTotalElements());
+    }
+
+     private static LigaResponse toResponse(Liga l) {
+        return new LigaResponse(l.getId(), l.getNome(), l.getUserId(), l.getCreatedAt());
+    }
+
+
 }

--- a/league-service/src/main/java/com/squadprisma/notesoccer/league_service/api/dto/LigaCreateRequest.java
+++ b/league-service/src/main/java/com/squadprisma/notesoccer/league_service/api/dto/LigaCreateRequest.java
@@ -1,10 +1,14 @@
 package com.squadprisma.notesoccer.league_service.api.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
 
 public record LigaCreateRequest(
         @NotBlank @Size(min = 3, max = 80)
-        String nome
+        String nome,
+        @NotNull UUID userId
 ) {
 }

--- a/league-service/src/main/java/com/squadprisma/notesoccer/league_service/api/dto/LigaResponse.java
+++ b/league-service/src/main/java/com/squadprisma/notesoccer/league_service/api/dto/LigaResponse.java
@@ -3,5 +3,5 @@ package com.squadprisma.notesoccer.league_service.api.dto;
 import java.time.Instant;
 import java.util.UUID;
 
-public record LigaResponse(UUID id, String nome, Instant createdAt) {
+public record LigaResponse(UUID id, String nome, UUID userId, Instant createdAt) {
 }

--- a/league-service/src/main/java/com/squadprisma/notesoccer/league_service/domain/entity/Liga.java
+++ b/league-service/src/main/java/com/squadprisma/notesoccer/league_service/domain/entity/Liga.java
@@ -7,7 +7,10 @@ import java.time.Instant;
 import java.util.UUID;
 
 @Entity
-@Table(name = "ligas", schema = "league_dev")
+@Table(name = "ligas", schema = "league_dev",
+indexes = {
+        @Index(name = "ix_ligas_user_id", columnList = "user_id")
+})
 @Getter
 @Setter
 @NoArgsConstructor
@@ -21,6 +24,9 @@ public class Liga {
 
     @Column(nullable = false, length = 80)
     private String nome;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
 
     @Column(name = "created_at", nullable = false)
     private Instant createdAt = Instant.now();

--- a/league-service/src/main/java/com/squadprisma/notesoccer/league_service/repository/LigaRepository.java
+++ b/league-service/src/main/java/com/squadprisma/notesoccer/league_service/repository/LigaRepository.java
@@ -1,9 +1,12 @@
 package com.squadprisma.notesoccer.league_service.repository;
 
 import com.squadprisma.notesoccer.league_service.domain.entity.Liga;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
 public interface LigaRepository extends JpaRepository<Liga, UUID> {
+    Page<Liga> findByUserId(UUID userId, Pageable pageable);
 }

--- a/league-service/src/main/java/com/squadprisma/notesoccer/league_service/service/LigaService.java
+++ b/league-service/src/main/java/com/squadprisma/notesoccer/league_service/service/LigaService.java
@@ -5,7 +5,11 @@ import com.squadprisma.notesoccer.league_service.domain.entity.Liga;
 import com.squadprisma.notesoccer.league_service.repository.LigaRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -14,9 +18,15 @@ public class LigaService {
     private final LigaRepository repo;
 
     @Transactional
-    public Liga create(LigaCreateRequest req) {
+    public Liga criar(LigaCreateRequest req) {
         Liga l = new Liga();
         l.setNome(req.nome().trim().replaceAll("\\s+"," "));
+        l.setUserId(req.userId());
         return repo.save(l);
+    }
+
+    public Page<Liga> listarPorUsuario(UUID userId, Pageable pageable){
+        return repo.findByUserId(userId, pageable);
+
     }
 }

--- a/league-service/src/test/java/com/squadprisma/notesoccer/league_service/LigaServiceTest.java
+++ b/league-service/src/test/java/com/squadprisma/notesoccer/league_service/LigaServiceTest.java
@@ -7,6 +7,8 @@ import com.squadprisma.notesoccer.league_service.service.LigaService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -22,13 +24,15 @@ public class LigaServiceTest {
     }
 
     @Test
-    void create_ok_trim_e_normaliza_espacos() {
-        var req = new LigaCreateRequest("  Liga    Zona   Norte  ");
+    void criar_ok_trim_e_normaliza_espacos() {
+        UUID ligaId = UUID.randomUUID();
+        var req = new LigaCreateRequest("  Liga    Zona   Norte  ", ligaId);
         when(repo.save(any(Liga.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        var liga = service.create(req);
+        var liga = service.criar(req);
 
         assertThat(liga.getNome()).isEqualTo("Liga Zona Norte");
+        assertThat(liga.getUserId()).isEqualTo(ligaId);
         verify(repo, times(1)).save(any(Liga.class));
     }
 

--- a/league-service/src/test/java/com/squadprisma/notesoccer/league_service/api/controller/LigaControllerTest.java
+++ b/league-service/src/test/java/com/squadprisma/notesoccer/league_service/api/controller/LigaControllerTest.java
@@ -12,6 +12,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.UUID;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -32,9 +34,9 @@ public class LigaControllerTest extends BaseControllerTest {
         Liga l = new Liga();
         l.setNome("Liga X");
 
-        Mockito.when(service.create(Mockito.any())).thenReturn(l);
+        Mockito.when(service.criar(Mockito.any())).thenReturn(l);
 
-        var body = new LigaCreateRequest("Liga X");
+        var body = new LigaCreateRequest("Liga X", UUID.randomUUID());
 
         mvc.perform(post("/api/v1/ligas")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/CreateLigaRequest.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/dto/CreateLigaRequest.java
@@ -1,10 +1,14 @@
 package com.squadprisma.notesoccer.orchestration_service.api.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
 
 public record CreateLigaRequest(
         @NotBlank @Size(min = 3, max = 80)
-        String nome
+        String nome,
+        @NotNull UUID userId
 ) {
 }

--- a/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationLigaControllerTest.java
+++ b/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationLigaControllerTest.java
@@ -49,7 +49,7 @@ public class OrchestrationLigaControllerTest {
         var resp = new LigaResponse(UUID.randomUUID(), "Liga Zona Norte", Instant.now());
         Mockito.when(service.criarLiga(any())).thenReturn(resp);
 
-        var body = new CreateLigaRequest("Liga Zona Norte");
+        var body = new CreateLigaRequest("Liga Zona Norte", UUID.randomUUID());
 
         mvc.perform(post("/api/v1/orquestrador/ligas")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -61,7 +61,7 @@ public class OrchestrationLigaControllerTest {
 
     @Test
     void post_criar_liga_400_validacao_nome_em_branco() throws Exception {
-        var body = new CreateLigaRequest("   "); // @NotBlank em DTO
+        var body = new CreateLigaRequest("   ", UUID.randomUUID()); // @NotBlank em DTO
 
         mvc.perform(post("/api/v1/orquestrador/ligas")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -74,7 +74,7 @@ public class OrchestrationLigaControllerTest {
         Mockito.when(service.criarLiga(any()))
                 .thenThrow(new ResponseStatusException(CONFLICT, "LEAGUE_ALREADY_EXISTS"));
 
-        var body = new CreateLigaRequest("Liga X");
+        var body = new CreateLigaRequest("Liga X", UUID.randomUUID());
 
         mvc.perform(post("/api/v1/orquestrador/ligas")
                         .contentType(MediaType.APPLICATION_JSON)

--- a/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/application/service/LeagueOrchestrationServiceTest.java
+++ b/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/application/service/LeagueOrchestrationServiceTest.java
@@ -47,10 +47,11 @@ public class LeagueOrchestrationServiceTest {
 
     @BeforeEach
     void setup() {
-        ligaReq = new CreateLigaRequest("Liga Zona Norte");
+        ligaId = UUID.randomUUID();
+
+        ligaReq = new CreateLigaRequest("Liga Zona Norte", ligaId);
         ligaResp = new LigaResponse(UUID.randomUUID(), "Liga Zona Norte", Instant.now());
 
-        ligaId = UUID.randomUUID();
         timeNome = "Atlético Jardim";
         timeResp = new TimeResponse(UUID.randomUUID(), ligaId, timeNome, Instant.now());
     }


### PR DESCRIPTION
### Contexto
Implementação do vínculo entre usuários e ligas, permitindo que cada liga pertença a um único usuário e que um usuário possa possuir várias ligas.

### Alterações principais
- Inclusão do campo `user_id` na entidade `Liga` e no schema `league_dev`.
- Ajustes nos DTOs e controllers do `league-service` e `orchestration-service`.
- Atualização dos testes unitários para refletir o novo vínculo.
- Padrão REST mantido (`/ligas/{ligaId}/times`).

### Validações
- Testes unitários executados com sucesso em ambos os serviços.
- Integração confirmada via Orchestration.
- Nenhum impacto no `user-service`.

### Próximos passos
- Validar via Postman a criação de ligas associadas ao usuário.
- Preparar integração futura para buscar ligas do usuário autenticado.