### PR TITLE
Chore: Configuração global de CORS no orchestration-service

### DIFF
--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/config/CorsConfig.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/config/CorsConfig.java
@@ -1,0 +1,29 @@
+package com.squadprisma.notesoccer.orchestration_service.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer(){
+        return new WebMvcConfigurer(){
+            @Override
+            public void addCorsMappings(CorsRegistry registry){
+                registry.addMapping("/api/**")
+                        .allowedOrigins(
+                                "http://localhost:4200",
+                                "https://notesoccer.netlify.app"
+                        )
+                        .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .exposedHeaders("Location")
+                        .allowCredentials(true)
+                        .maxAge(3600);
+            }
+        };
+    }
+}


### PR DESCRIPTION
Implementada configuração global de CORS para permitir integração entre o front-end Angular e o backend.
 - Adicionada classe CorsConfig em config/
 - Permitidos domínios localhost:4200 e notesoccer.netlify.app
 - Métodos e headers liberados globalmente para endpoints /api/**

Essa configuração destrava a integração do front com o back antes da implantação do Spring Security.