### PR TITLE
chore: configuracao da openapi

### DIFF
--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/config/OpenApiConfig.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/config/OpenApiConfig.java
@@ -1,0 +1,21 @@
+package com.squadprisma.notesoccer.orchestration_service.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI(){
+        Server httpServer = new Server()
+                .url("https://notesoccer.lavicestas.com.br")
+                .description("Notesoccer via Cloudflare Tunnel");
+
+        return new OpenAPI().servers(List.of(httpServer));
+    }
+}


### PR DESCRIPTION
chore: configuracao da openapi para atualizar rotas de requisicao do swagger para http. Necessario para utilizacao temporaria enquanto o Render esta for