### PR TITLE
Integração CRUD de Liga/Time no Orchestration Service + Testes

### DIFF
--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationLigaController.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationLigaController.java
@@ -93,4 +93,46 @@ public class OrchestrationLigaController {
 
         return resp;
     }
+
+    @DeleteMapping("/{ligaId}/times/{timeId}")
+    @Operation(summary = "Excluir time de uma liga")
+    public ResponseEntity<Void> deletarTime(
+            @PathVariable UUID ligaId,
+            @PathVariable UUID timeId
+    ) {
+        log.info("Orchestrator - Excluir time de liga. ligaId={}, timeId={}", ligaId, timeId);
+
+        service.deletarTime(ligaId, timeId);
+
+        log.info("Orchestrator - Time excluído com sucesso. ligaId={}, timeId={}", ligaId, timeId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{ligaId}")
+    @Operation(summary = "Excluir liga")
+    public ResponseEntity<Void> deletarLiga(@PathVariable UUID ligaId) {
+        log.info("Orchestrator - Excluir liga. ligaId={}", ligaId);
+
+        service.deletarLiga(ligaId);
+
+        log.info("Orchestrator - Liga excluída com sucesso. ligaId={}", ligaId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    @Operation(summary = "Listar ligas de um usuário")
+    public PageResponse<LigaResponse> listarLigasPorUsuario(
+            @RequestParam UUID userId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        log.info("Orchestrator - Listar ligas por usuário. userId={}, page={}, size={}", userId, page, size);
+
+        var resp = service.listarLigasPorUsuario(userId, page, size);
+
+        log.debug("Orchestrator - Listagem de ligas concluída. userId={}, totalElements={}",
+                userId, resp.totalElements());
+
+        return resp;
+    }
 }

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/exceptions/GlobalExceptionHandler.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/api/exceptions/GlobalExceptionHandler.java
@@ -1,13 +1,12 @@
 package com.squadprisma.notesoccer.orchestration_service.api.exceptions;
 
 import com.squadprisma.notesoccer.orchestration_service.domain.exception.ConflictException;
-import com.squadprisma.notesoccer.orchestration_service.infra.DownstreamClientException;
+import com.squadprisma.notesoccer.orchestration_service.infra.exceptionInfra.DownstreamClientException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/application/port/out/LeagueServicePort.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/application/port/out/LeagueServicePort.java
@@ -11,4 +11,7 @@ public interface LeagueServicePort {
     List<TimeResponse> criarTimesLote(UUID ligaId, List<CreateTimeLoteRequest> request);
     PageResponse<TimeResponse> listarTimes(UUID ligaId, int page, int size);
     TimeCountResponse contarTimes(UUID ligaId);
+    void deletarTime(UUID ligaId, UUID timeId);
+    void deletarLiga(UUID ligaId);
+    PageResponse<LigaResponse> listarLigasPorUsuario(UUID userId, int page, int size);
 }

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/application/service/LeagueOrchestrationService.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/application/service/LeagueOrchestrationService.java
@@ -103,4 +103,62 @@ public class LeagueOrchestrationService {
                 ligaId, resp.count());
         return resp;
     }
+
+    public void deletarTime(UUID ligaId, UUID timeId) {
+        log.info("[ORC-LEAGUE] Iniciando exclusão de time. ligaId={}, timeId={}", ligaId, timeId);
+        try {
+            port.deletarTime(ligaId, timeId);
+            log.info("[ORC-LEAGUE] Time excluído com sucesso no league-service. ligaId={}, timeId={}", ligaId, timeId);
+        } catch (FeignException.NotFound ex) {
+            log.warn("[ORC-LEAGUE] Time não encontrado ao tentar excluir. ligaId={}, timeId={}, detalhe={}",
+                    ligaId, timeId, ex.contentUTF8());
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.contentUTF8());
+        } catch (FeignException.Conflict ex) {
+            log.warn("[ORC-LEAGUE] Conflito ao excluir time. ligaId={}, timeId={}, detalhe={}",
+                    ligaId, timeId, ex.contentUTF8());
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ex.contentUTF8());
+        } catch (RetryableException ex) {
+            log.error("[ORC-LEAGUE] Timeout ao chamar league-service na exclusão de time. ligaId={}, timeId={}",
+                    ligaId, timeId, ex);
+            throw new ResponseStatusException(HttpStatus.GATEWAY_TIMEOUT, "league-service timeout");
+        } catch (FeignException ex) {
+            log.error("[ORC-LEAGUE] Erro genérico do league-service ao excluir time. ligaId={}, timeId={}, status={}",
+                    ligaId, timeId, ex.status(), ex);
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "league-service error: " + ex.status());
+        }
+    }
+
+    public void deletarLiga(UUID ligaId) {
+        log.info("[ORC-LEAGUE] Iniciando exclusão de liga. ligaId={}", ligaId);
+        try {
+            port.deletarLiga(ligaId);
+            log.info("[ORC-LEAGUE] Liga excluída com sucesso no league-service. ligaId={}", ligaId);
+        } catch (FeignException.NotFound ex) {
+            log.warn("[ORC-LEAGUE] Liga não encontrada ao tentar excluir. ligaId={}, detalhe={}",
+                    ligaId, ex.contentUTF8());
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.contentUTF8());
+        } catch (FeignException.Conflict ex) {
+            log.warn("[ORC-LEAGUE] Conflito ao excluir liga. ligaId={}, detalhe={}",
+                    ligaId, ex.contentUTF8());
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ex.contentUTF8());
+        } catch (RetryableException ex) {
+            log.error("[ORC-LEAGUE] Timeout ao chamar league-service na exclusão de liga. ligaId={}", ligaId, ex);
+            throw new ResponseStatusException(HttpStatus.GATEWAY_TIMEOUT, "league-service timeout");
+        } catch (FeignException ex) {
+            log.error("[ORC-LEAGUE] Erro genérico do league-service ao excluir liga. ligaId={}, status={}",
+                    ligaId, ex.status(), ex);
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "league-service error: " + ex.status());
+        }
+    }
+
+    public PageResponse<LigaResponse> listarLigasPorUsuario(UUID userId, int page, int size) {
+        log.info("[ORC-LEAGUE] Listando ligas do usuário. userId={}, page={}, size={}", userId, page, size);
+
+        var resp = port.listarLigasPorUsuario(userId, page, size);
+
+        log.debug("[ORC-LEAGUE] Listagem de ligas concluída. userId={}, totalElements={}",
+                userId, resp.totalElements());
+
+        return resp;
+    }
 }

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/config/FeignClientsConfig.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/config/FeignClientsConfig.java
@@ -1,6 +1,6 @@
 package com.squadprisma.notesoccer.orchestration_service.config;
 
-import com.squadprisma.notesoccer.orchestration_service.infra.DownstreamHttpException;
+import com.squadprisma.notesoccer.orchestration_service.infra.exceptionInfra.DownstreamHttpException;
 import feign.Util;
 import feign.codec.ErrorDecoder;
 import org.springframework.cloud.openfeign.EnableFeignClients;

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/clients/LeagueServiceClient.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/clients/LeagueServiceClient.java
@@ -36,4 +36,17 @@ public interface LeagueServiceClient {
 
     @GetMapping("/api/v1/times/count")
     TimeCountResponse contarTimes(@RequestParam("ligaId") UUID ligaId);
+
+    @DeleteMapping("/api/v1/times/{timeId}")
+    void deleteTime(@PathVariable UUID timeId, @RequestParam UUID ligaId);
+
+    @DeleteMapping("/api/v1/ligas/{ligaId}")
+    void deleteLeague(@PathVariable UUID ligaId);
+
+    @GetMapping("/api/v1/ligas")
+    PageResponse<LigaResponse> listLeaguesByUser(
+            @RequestParam UUID userId,
+            @RequestParam int page,
+            @RequestParam int size
+    );
 }

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/clients/LeagueServiceFeignAdapter.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/clients/LeagueServiceFeignAdapter.java
@@ -38,4 +38,19 @@ public class LeagueServiceFeignAdapter implements LeagueServicePort {
     public TimeCountResponse contarTimes(UUID ligaId) {
         return client.contarTimes(ligaId);
     }
+
+    @Override
+    public void deletarTime(UUID ligaId, UUID timeId) {
+        client.deleteTime(ligaId, timeId);
+    }
+
+    @Override
+    public void deletarLiga(UUID ligaId) {
+        client.deleteLeague(ligaId);
+    }
+
+    @Override
+    public PageResponse<LigaResponse> listarLigasPorUsuario(UUID userId, int page, int size) {
+        return client.listLeaguesByUser(userId, page, size);
+    }
 }

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/exceptionInfra/DownstreamClientException.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/exceptionInfra/DownstreamClientException.java
@@ -1,4 +1,4 @@
-package com.squadprisma.notesoccer.orchestration_service.infra;
+package com.squadprisma.notesoccer.orchestration_service.infra.exceptionInfra;
 
 import org.springframework.http.HttpStatus;
 

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/exceptionInfra/DownstreamHttpException.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/exceptionInfra/DownstreamHttpException.java
@@ -1,4 +1,4 @@
-package com.squadprisma.notesoccer.orchestration_service.infra;
+package com.squadprisma.notesoccer.orchestration_service.infra.exceptionInfra;
 
 import org.springframework.http.HttpStatus;
 

--- a/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/feign/DownstreamErrorDecoder.java
+++ b/orchestration-service/src/main/java/com/squadprisma/notesoccer/orchestration_service/infra/feign/DownstreamErrorDecoder.java
@@ -2,7 +2,7 @@ package com.squadprisma.notesoccer.orchestration_service.infra.feign;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.squadprisma.notesoccer.orchestration_service.infra.DownstreamClientException;
+import com.squadprisma.notesoccer.orchestration_service.infra.exceptionInfra.DownstreamClientException;
 import feign.Response;
 import feign.codec.ErrorDecoder;
 import org.springframework.http.HttpStatus;

--- a/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationLigaControllerTest.java
+++ b/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/api/controller/OrchestrationLigaControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -24,9 +25,9 @@ import static org.hamcrest.Matchers.containsString;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.verify;
 import static org.springframework.http.HttpStatus.CONFLICT;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -128,5 +129,83 @@ public class OrchestrationLigaControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.ligaId").value(ligaId.toString()))
                 .andExpect(jsonPath("$.count").value(7));
+    }
+
+    @Test
+    void delete_league_204() throws Exception {
+        UUID ligaId = UUID.randomUUID();
+
+        mvc.perform(delete("/api/v1/orquestrador/ligas/{ligaId}", ligaId))
+                .andExpect(status().isNoContent());
+
+        verify(service).deletarLiga(ligaId);
+    }
+
+    @Test
+    void delete_league_404_not_found() throws Exception {
+        UUID ligaId = UUID.randomUUID();
+
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "LEAGUE_NOT_FOUND"))
+                .when(service)
+                .deletarLiga(ligaId);
+
+        mvc.perform(delete("/api/v1/orquestrador/ligas/{ligaId}", ligaId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("LEAGUE_NOT_FOUND"));
+    }
+
+    @Test
+    void get_leagues_by_user_200() throws Exception {
+        UUID userId = UUID.randomUUID();
+        UUID ligaId = UUID.randomUUID();
+
+        LigaResponse liga = new LigaResponse(
+                ligaId,
+                "Liga do Leo",
+                Instant.parse("2025-01-01T10:00:00Z")
+        );
+
+        PageResponse<LigaResponse> page = new PageResponse<>(
+                List.of(liga),
+                0,
+                20,
+                1L,
+                1
+        );
+
+        Mockito.when(service.listarLigasPorUsuario(eq(userId), anyInt(), anyInt()))
+                .thenReturn(page);
+
+        mvc.perform(get("/api/v1/orquestrador/ligas")
+                        .param("userId", userId.toString())
+                        .param("page", "0")
+                        .param("size", "20"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].id").value(ligaId.toString()))
+                .andExpect(jsonPath("$.content[0].nome").value("Liga do Leo"))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+    @Test
+    void delete_time_204() throws Exception {
+        UUID ligaId = UUID.randomUUID();
+        UUID timeId = UUID.randomUUID();
+
+        mvc.perform(delete("/api/v1/orquestrador/ligas/{ligaId}/times/{timeId}", ligaId, timeId))
+                .andExpect(status().isNoContent());
+
+        verify(service).deletarTime(ligaId, timeId);
+    }
+    @Test
+    void delete_time_404_team_not_found() throws Exception {
+        UUID ligaId = UUID.randomUUID();
+        UUID timeId = UUID.randomUUID();
+
+        Mockito.doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "TEAM_NOT_FOUND"))
+                .when(service)
+                .deletarTime(ligaId, timeId);
+
+        mvc.perform(delete("/api/v1/orquestrador/ligas/{ligaId}/times/{timeId}", ligaId, timeId))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value("TEAM_NOT_FOUND"));
     }
 }

--- a/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/application/service/LeagueOrchestrationServiceTest.java
+++ b/orchestration-service/src/test/java/com/squadprisma/notesoccer/orchestration_service/application/service/LeagueOrchestrationServiceTest.java
@@ -197,4 +197,170 @@ public class LeagueOrchestrationServiceTest {
         verify(port).contarTimes(ligaId);
         verifyNoMoreInteractions(port);
     }
+
+    @Test
+    void deletarTime_deveDelegarParaPorta_eNaoLancarErro() {
+        UUID timeId = UUID.randomUUID();
+        doNothing().when(port).deletarTime(ligaId, timeId);
+
+        service.deletarTime(ligaId, timeId);
+
+        verify(port).deletarTime(ligaId, timeId);
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void deletarTime_deveMapear404ParaResponseStatusExceptionNotFound() {
+        UUID timeId = UUID.randomUUID();
+        FeignException.NotFound notFound = mock(FeignException.NotFound.class);
+        when(notFound.contentUTF8()).thenReturn("TEAM_NOT_FOUND");
+
+        doThrow(notFound).when(port).deletarTime(ligaId, timeId);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.deletarTime(ligaId, timeId));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(ex.getReason()).isEqualTo("TEAM_NOT_FOUND");
+        verify(port).deletarTime(ligaId, timeId);
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void deletarTime_deveMapear409ParaResponseStatusExceptionConflict() {
+        UUID timeId = UUID.randomUUID();
+        FeignException.Conflict conflict = mock(FeignException.Conflict.class);
+        when(conflict.contentUTF8()).thenReturn("TEAM_IN_USE");
+
+        doThrow(conflict).when(port).deletarTime(ligaId, timeId);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.deletarTime(ligaId, timeId));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(ex.getReason()).isEqualTo("TEAM_IN_USE");
+        verify(port).deletarTime(ligaId, timeId);
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void deletarTime_deveMapearRetryableExceptionPara504() {
+        UUID timeId = UUID.randomUUID();
+        RetryableException retryable = mock(RetryableException.class);
+
+        doThrow(retryable).when(port).deletarTime(ligaId, timeId);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.deletarTime(ligaId, timeId));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.GATEWAY_TIMEOUT);
+        assertThat(ex.getReason()).isEqualTo("league-service timeout");
+        verify(port).deletarTime(ligaId, timeId);
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void deletarTime_deveMapearFeignGenericoPara502() {
+        UUID timeId = UUID.randomUUID();
+        FeignException generic = mock(FeignException.class);
+        when(generic.status()).thenReturn(500);
+
+        doThrow(generic).when(port).deletarTime(ligaId, timeId);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.deletarTime(ligaId, timeId));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_GATEWAY);
+        assertThat(ex.getReason()).isEqualTo("league-service error: 500");
+        verify(port).deletarTime(ligaId, timeId);
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void deletarLiga_deveDelegarParaPorta_eNaoLancarErro() {
+        doNothing().when(port).deletarLiga(ligaId);
+
+        service.deletarLiga(ligaId);
+
+        verify(port).deletarLiga(ligaId);
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void deletarLiga_deveMapear404ParaNotFound() {
+        FeignException.NotFound notFound = mock(FeignException.NotFound.class);
+        when(notFound.contentUTF8()).thenReturn("LEAGUE_NOT_FOUND");
+
+        doThrow(notFound).when(port).deletarLiga(ligaId);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.deletarLiga(ligaId));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(ex.getReason()).isEqualTo("LEAGUE_NOT_FOUND");
+        verify(port).deletarLiga(ligaId);
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void deletarLiga_deveMapear409ParaConflict() {
+        FeignException.Conflict conflict = mock(FeignException.Conflict.class);
+        when(conflict.contentUTF8()).thenReturn("LEAGUE_IN_USE");
+
+        doThrow(conflict).when(port).deletarLiga(ligaId);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.deletarLiga(ligaId));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+        assertThat(ex.getReason()).isEqualTo("LEAGUE_IN_USE");
+        verify(port).deletarLiga(ligaId);
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void deletarLiga_deveMapearRetryablePara504() {
+        RetryableException retryable = mock(RetryableException.class);
+
+        doThrow(retryable).when(port).deletarLiga(ligaId);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.deletarLiga(ligaId));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.GATEWAY_TIMEOUT);
+        assertThat(ex.getReason()).isEqualTo("league-service timeout");
+        verify(port).deletarLiga(ligaId);
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void deletarLiga_deveMapearFeignGenericoPara502() {
+        FeignException generic = mock(FeignException.class);
+        when(generic.status()).thenReturn(502);
+
+        doThrow(generic).when(port).deletarLiga(ligaId);
+
+        ResponseStatusException ex = assertThrows(ResponseStatusException.class,
+                () -> service.deletarLiga(ligaId));
+
+        assertThat(ex.getStatusCode()).isEqualTo(HttpStatus.BAD_GATEWAY);
+        assertThat(ex.getReason()).isEqualTo("league-service error: 502");
+        verify(port).deletarLiga(ligaId);
+        verifyNoMoreInteractions(port);
+    }
+
+    @Test
+    void listarLigasPorUsuario_deveDelegarParaPorta() {
+        UUID userId = UUID.randomUUID();
+        LigaResponse lr = new LigaResponse(UUID.randomUUID(), "Liga X", Instant.now());
+        PageResponse<LigaResponse> page = new PageResponse<>(List.of(lr), 0, 20, 1, 1);
+
+        when(port.listarLigasPorUsuario(userId, 0, 20)).thenReturn(page);
+
+        var out = service.listarLigasPorUsuario(userId, 0, 20);
+
+        assertThat(out.totalElements()).isEqualTo(1);
+        verify(port).listarLigasPorUsuario(userId, 0, 20);
+        verifyNoMoreInteractions(port);
+    }
 }


### PR DESCRIPTION
Este PR implementa a integração completa do Orchestration Service com as novas
funcionalidades do League Service.

### Principais entregas

✔ Adiciona métodos no LeagueOrchestrationService:
- deletar liga
- deletar time
- listar ligas por usuário

✔ Padroniza tratamento de erros Feign → ResponseStatusException  
✔ Atualiza OrchestrationLigaController com novos endpoints  
✔ Adiciona test suite abrangente:
- 55 testes passando
- cobertura de 409, 404, 502, 504
- validações de body, path e delegação correta

### Impacto técnico
- Orquestrador agora suporta todo CRUD de ligas e times
- Backend do front-end pode consumir rotas consolidadas e seguras

### Como testar
- Executar `mvn clean test`
- Validar no Swagger/OpenAPI do Orchestration Service